### PR TITLE
Feat/create tooltip fav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lahijunat-live",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lahijunat-live",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@astrojs/markdown-component": "^1.0.5",
         "@astrojs/preact": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lahijunat-live",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build && workbox generateSW workbox-config.cjs",

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -80,6 +80,7 @@ export default function TrainCard({
 	const [hasDeparted, setHasDeparted] = useState(false);
 	const [opacity, setOpacity] = useState(1);
 	const [trackMemory, setTrackMemory] = useState<Record<string, { track: string; timestamp: number }>>({});
+	const [showTooltip, setShowTooltip] = useState(false);
 
 	// Memoize all time-dependent calculations
 	const {
@@ -150,6 +151,15 @@ export default function TrainCard({
 			cardStyle,
 		};
 	}, [train, stationCode, destinationCode, currentTime, isHighlighted]);
+
+	// Check if user has seen the tooltip before
+	useEffect(() => {
+		const hasSeenTooltip = localStorage.getItem('hasSeenFavoriteTooltip');
+		if (!hasSeenTooltip && !train.cancelled && minutesToDeparture !== null && minutesToDeparture > 0) {
+			setShowTooltip(true);
+			localStorage.setItem('hasSeenFavoriteTooltip', 'true');
+		}
+	}, [train.cancelled, minutesToDeparture]);
 
 	// Call onDepart when the train transitions from not departed to departed
 	useEffect(() => {
@@ -349,6 +359,12 @@ export default function TrainCard({
 							class="flex-shrink-0 h-12 w-12 flex items-center justify-center text-xl font-bold focus:outline-none transition-transform duration-150 hover:scale-110 relative group border-none outline-none ring-0"
 							style={{ outline: 'none', border: 'none', boxShadow: 'none' }}
 						>
+							{showTooltip && (
+								<div class="absolute -top-2 left-1/2 transform -translate-x-1/2 -translate-y-full bg-gray-900 text-white text-sm px-3 py-2 rounded-lg shadow-lg whitespace-nowrap z-50">
+									{t("clickToFavorite")}
+									<div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 rotate-45 w-2 h-2 bg-gray-900" />
+								</div>
+							)}
 							{isHighlighted ? (
 								<span class="absolute inset-0 flex items-center justify-center">
 									<svg

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -382,12 +382,12 @@ export default function TrainCard({
 								</button>
 							)}
 							{isHighlighted ? (
-								<span class="absolute inset-0 flex items-center justify-center">
+								<span class={`h-12 w-12 rounded-full flex items-center justify-center relative border-2 ${train.cancelled ? 'border-[#d4004d]' : 'border-[#8c4799]'} bg-transparent`}>
 									<svg
 										viewBox="0 0 48 48"
-										class="w-12 h-12"
-										fill={train.cancelled ? '#d4004d' : '#6b2c75'}
-										stroke={train.cancelled ? '#d4004d' : '#6b2c75'}
+										class="w-11 h-11"
+										fill={train.cancelled ? '#d4004d' : '#8c4799'}
+										stroke={train.cancelled ? '#d4004d' : '#8c4799'}
 									>
 										<title>{isHighlighted ? t("favorite") : t("unfavorite")}</title>
 										<polygon points="24,3 30.9,17.8 47,18.6 34,29.7 38.2,45 24,36.6 9.8,45 14,29.7 1,18.6 17.1,17.8" />

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -360,10 +360,26 @@ export default function TrainCard({
 							style={{ outline: 'none', border: 'none', boxShadow: 'none' }}
 						>
 							{showTooltip && (
-								<div class="absolute -top-2 left-1/2 transform -translate-x-1/2 -translate-y-full bg-gray-900 text-white text-sm px-3 py-2 rounded-lg shadow-lg whitespace-nowrap z-50">
-									{t("clickToFavorite")}
-									<div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 rotate-45 w-2 h-2 bg-gray-900" />
-								</div>
+								<button
+									type="button"
+									class="absolute -top-2 left-1/2 transform -translate-x-1/2 -translate-y-full bg-[#6b2c75] text-white text-sm px-3 py-2 rounded-lg shadow-lg border-2 border-white whitespace-normal break-words max-w-xs max-w-[90vw] text-center z-50 cursor-pointer"
+									onClick={e => { e.stopPropagation(); setShowTooltip(false); }}
+									onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); setShowTooltip(false); } }}
+									tabIndex={0}
+									aria-label={t("closeTooltip")}
+								>
+									<div class="flex items-center gap-2">
+									
+										<span>{t("favoriteTooltip")}</span>
+									</div>
+									{/* Arrow */}
+									<div class="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 w-3 h-3 z-10">
+										<svg width="100%" height="100%" viewBox="0 0 12 12">
+											<title>Tooltip arrow</title>
+											<rect x="2" y="2" width="8" height="8" rx="2" fill="#6b2c75" stroke="white" strokeWidth="2" transform="rotate(45 6 6)" />
+										</svg>
+									</div>
+								</button>
 							)}
 							{isHighlighted ? (
 								<span class="absolute inset-0 flex items-center justify-center">

--- a/src/content/changelog/v1.5.1.md
+++ b/src/content/changelog/v1.5.1.md
@@ -1,0 +1,11 @@
+---
+version: "1.5.1"
+date: "2025-06-07"
+---
+
+## Uudet ominaisuudet
+
+- Parannettu suosikkijunan tooltipin saavutettavuutta ja ulkoasua: tooltip sulkeutuu klikatessa eikä enää laukaise suosikiksi asettamista
+- Tooltipin nuoli ja tähti-ikoni korjattu ja tehty näkyvämmäksi
+- Korostetun junan tähti-ikoni on nyt ympyrän sisällä, kuten korostamattomilla junilla
+- Lisätty puuttuva käännösavaimen "closeTooltip" käännökset saavutettavuuden parantamiseksi

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -35,6 +35,8 @@ export const translations: Translations = {
 		trainIcon: "Juna-ikoni lainattu",
 		changelog: "Muutosloki",
 		showMore: "Näytä lisää",
+		favoriteTooltip: "Klikkaa suosikiksi ja korosta juna listassa",
+		starIcon: "Tähti-ikoni",
 	},
 	en: {
 		title: "Local Trains Live | Real-time schedules for local trains",
@@ -64,6 +66,8 @@ export const translations: Translations = {
 		trainIcon: "Train icon from",
 		changelog: "Changelog",
 		showMore: "Show more",
+		favoriteTooltip: "Click to favorite and highlight this train in the list",
+		starIcon: "Star icon",
 	},
 };
 

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -37,6 +37,7 @@ export const translations: Translations = {
 		showMore: "Näytä lisää",
 		favoriteTooltip: "Klikkaa suosikiksi ja korosta juna listassa",
 		starIcon: "Tähti-ikoni",
+		closeTooltip: "Sulje suosikkivihje",
 	},
 	en: {
 		title: "Local Trains Live | Real-time schedules for local trains",
@@ -68,6 +69,7 @@ export const translations: Translations = {
 		showMore: "Show more",
 		favoriteTooltip: "Click to favorite and highlight this train in the list",
 		starIcon: "Star icon",
+		closeTooltip: "Close favorite tooltip",
 	},
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a tooltip above the favorite button on train cards to guide users about the favorite feature. The tooltip appears only once per user for trains that have not departed and are not cancelled.
  - Improved tooltip accessibility and appearance, including clearer icons and a dismissible design that prevents accidental favoriting.
- **Localization**
  - Added new translations for the tooltip and star icon in both Finnish and English.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->