### PR TITLE
fix: extend train data lookback to show delayed trains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lahijunat-live",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lahijunat-live",
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"dependencies": {
 				"@astrojs/markdown-component": "^1.0.5",
 				"@astrojs/preact": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lahijunat-live",
 	"type": "module",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build && workbox generateSW workbox-config.cjs",

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -368,12 +368,12 @@ export default function TrainList({
 		.filter((train) => {
 			// Filter out trains that have been manually marked as departed
 			if (departedTrains.has(train.trainNumber)) return false;
-			
+
 			// Filter out trains that have actually departed (departed more than 2 minutes ago)
 			const departureRow = train.timeTableRows.find(
 				(row) => row.stationShortCode === stationCode && row.type === "DEPARTURE",
 			);
-			
+
 			if (departureRow) {
 				const departureTime = new Date(
 					departureRow.liveEstimateTime ?? departureRow.scheduledTime,
@@ -381,11 +381,11 @@ export default function TrainList({
 				const minutesToDeparture = Math.floor(
 					(departureTime.getTime() - currentTime.getTime()) / (1000 * 60),
 				);
-				
+
 				// Don't show trains that departed more than 2 minutes ago
 				return minutesToDeparture > -2;
 			}
-			
+
 			return true;
 		})
 		.slice(0, displayedTrainCount);

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -365,7 +365,29 @@ export default function TrainList({
 	);
 
 	const displayedTrains = (state.trains || [])
-		.filter((train) => !departedTrains.has(train.trainNumber))
+		.filter((train) => {
+			// Filter out trains that have been manually marked as departed
+			if (departedTrains.has(train.trainNumber)) return false;
+			
+			// Filter out trains that have actually departed (departed more than 2 minutes ago)
+			const departureRow = train.timeTableRows.find(
+				(row) => row.stationShortCode === stationCode && row.type === "DEPARTURE",
+			);
+			
+			if (departureRow) {
+				const departureTime = new Date(
+					departureRow.liveEstimateTime ?? departureRow.scheduledTime,
+				);
+				const minutesToDeparture = Math.floor(
+					(departureTime.getTime() - currentTime.getTime()) / (1000 * 60),
+				);
+				
+				// Don't show trains that departed more than 2 minutes ago
+				return minutesToDeparture > -2;
+			}
+			
+			return true;
+		})
 		.slice(0, displayedTrainCount);
 	const hasMoreTrains = (state.trains || []).length > displayedTrainCount;
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -493,7 +493,7 @@ export async function fetchTrains(
 		async () => {
 			const params = new URLSearchParams({
 				limit: "100",
-				startDate: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(), // 3 hours ago to capture delayed trains
+				startDate: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1 hour ago to capture delayed trains
 				endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
 			});
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -493,7 +493,7 @@ export async function fetchTrains(
 		async () => {
 			const params = new URLSearchParams({
 				limit: "100",
-				startDate: new Date(Date.now() - 1 * 60 * 1000).toISOString(),
+				startDate: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(), // 3 hours ago to capture delayed trains
 				endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
 			});
 


### PR DESCRIPTION
Increase API startDate from 1 minute to 1 hour ago to capture
trains that were scheduled earlier but are delayed and still
relevant. This fixes the issue where delayed trains whose
original departure time has passed were not being displayed
on lähijunat.live despite still being shown on official
departure boards.

Fixes issue #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved train data retrieval to include trains delayed by up to one hour, ensuring more comprehensive results.
  * Enhanced train list filtering to exclude trains that departed more than two minutes ago, providing more accurate real-time information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->