### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-station-query.yml
+++ b/.github/workflows/update-station-query.yml
@@ -1,4 +1,6 @@
 name: Update Station Query
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/nikosalonen/lahijunat.live/security/code-scanning/1](https://github.com/nikosalonen/lahijunat.live/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or the specific job that requires it. Since the workflow pushes changes to the repository, it needs `contents: write` permission. The best way to fix this is to add the following block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. This change should be made in `.github/workflows/update-station-query.yml`, above the `on:` key. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
