### PR TITLE
Feat/departure logic refinements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lahijunat-live",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lahijunat-live",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"dependencies": {
 				"@astrojs/markdown-component": "^1.0.5",
 				"@astrojs/preact": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lahijunat-live",
 	"type": "module",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build && workbox generateSW workbox-config.cjs",

--- a/src/components/TimeDisplay.tsx
+++ b/src/components/TimeDisplay.tsx
@@ -16,13 +16,14 @@ const TimeDisplay = ({
 	isCancelled?: boolean;
 }) => {
 	useLanguageChange();
+	const rowIsCancelled = Boolean(isCancelled ?? departureRow.cancelled);
 	return (
 			<span
-				class={`text-xl sm:text-2xl font-medium ${isCancelled ? "line-through text-gray-500 dark:text-gray-300" : "text-gray-800 dark:text-gray-100"} min-w-0 relative pt-8 sm:pt-6`}
+				class={`text-xl sm:text-2xl font-medium ${rowIsCancelled ? "line-through text-gray-500 dark:text-gray-300" : "text-gray-800 dark:text-gray-100"} min-w-0 relative pt-8 sm:pt-6`}
 			>
 				{departureRow.liveEstimateTime &&
 				timeDifferenceMinutes > 0 &&
-				!isCancelled ? (
+				!rowIsCancelled ? (
 					<>
 						<output
 							aria-label={`${t("late")} ${timeDifferenceMinutes} ${t("minutes")}`}
@@ -30,10 +31,10 @@ const TimeDisplay = ({
 						>
 							{`+${timeDifferenceMinutes} min`}
 						</output>
-						<TimeRow departureRow={departureRow} arrivalRow={arrivalRow} isCancelled={departureRow.cancelled} />
+						<TimeRow departureRow={departureRow} arrivalRow={arrivalRow} isCancelled={rowIsCancelled} />
 					</>
 				) : (
-					<TimeRow departureRow={departureRow} arrivalRow={arrivalRow} isCancelled={departureRow.cancelled} />
+					<TimeRow departureRow={departureRow} arrivalRow={arrivalRow} isCancelled={rowIsCancelled} />
 				)}
 			</span>
 	);

--- a/src/components/TimeDisplay.tsx
+++ b/src/components/TimeDisplay.tsx
@@ -26,7 +26,7 @@ const TimeDisplay = ({
 					<>
 						<output
 							aria-label={`${t("late")} ${timeDifferenceMinutes} ${t("minutes")}`}
-							class="absolute top-0 left-0 px-3 py-1 sm:px-2 sm:py-0.5 bg-gradient-to-r from-yellow-400 to-yellow-500 text-black rounded-lg text-base sm:text-base font-semibold shadow-lg"
+							class="absolute top-0 left-0 px-2 py-0.5 sm:px-2 sm:py-0.5 bg-gradient-to-r from-yellow-400 to-yellow-500 text-black rounded-lg text-sm sm:text-base font-semibold shadow-lg"
 						>
 							{`+${timeDifferenceMinutes} min`}
 						</output>

--- a/src/components/TimeRow.tsx
+++ b/src/components/TimeRow.tsx
@@ -10,16 +10,18 @@ const TimeRow = ({
 	arrivalRow?: Train["timeTableRows"][0];
 	isCancelled?: boolean;
 }) => {
+	const rowIsCancelled = Boolean(isCancelled ?? departureRow.cancelled);
 	const useLiveEstimate = Boolean(
 		departureRow.liveEstimateTime &&
-		!isCancelled &&
+		!rowIsCancelled &&
 		departureRow.differenceInMinutes !== undefined &&
 		departureRow.differenceInMinutes > 1,
 	);
 
 	const useArrivalLiveEstimate = Boolean(
 		arrivalRow?.liveEstimateTime &&
-		!isCancelled &&
+		!rowIsCancelled &&
+		!arrivalRow?.cancelled &&
 		arrivalRow?.differenceInMinutes !== undefined &&
 		(arrivalRow?.differenceInMinutes as number) > 1,
 	);
@@ -34,15 +36,17 @@ const TimeRow = ({
 
 	return (
 			<span class="block w-full text-gray-600 dark:text-gray-300 text-base sm:text-lg whitespace-nowrap">
-				{useLiveEstimate ? "~" : " "}
+				{useLiveEstimate && <span aria-hidden="true">~</span>}
 				<time datetime={displayedTime}>
 					{formatTime(displayedTime)}
 				</time>
-				<span class="mx-1 sm:mx-2">→</span>
-				{arrivalRow && (
+				{arrivalRow && <span class="mx-1 sm:mx-2">→</span>}
+				{arrivalRow && arrivalDisplayedTime && (
 					<>
-						{useArrivalLiveEstimate && "~"}
-						{arrivalDisplayedTime && formatTime(arrivalDisplayedTime)}
+						{useArrivalLiveEstimate && <span aria-hidden="true">~</span>}
+						<time datetime={arrivalDisplayedTime}>
+							{formatTime(arrivalDisplayedTime)}
+						</time>
 					</>
 				)}
 			</span>

--- a/src/components/TimeRow.tsx
+++ b/src/components/TimeRow.tsx
@@ -33,12 +33,12 @@ const TimeRow = ({
 		: arrivalRow?.scheduledTime;
 
 	return (
-			<span class="text-gray-600 dark:text-gray-300 text-lg sm:text-lg whitespace-nowrap overflow-hidden text-ellipsis">
+			<span class="block w-full text-gray-600 dark:text-gray-300 text-base sm:text-lg whitespace-nowrap">
 				{useLiveEstimate ? "~" : " "}
 				<time datetime={displayedTime}>
 					{formatTime(displayedTime)}
 				</time>
-				<span class="mx-2">→</span>
+				<span class="mx-1 sm:mx-2">→</span>
 				{arrivalRow && (
 					<>
 						{useArrivalLiveEstimate && "~"}

--- a/src/components/TimeRow.tsx
+++ b/src/components/TimeRow.tsx
@@ -17,9 +17,20 @@ const TimeRow = ({
 		departureRow.differenceInMinutes > 1,
 	);
 
+	const useArrivalLiveEstimate = Boolean(
+		arrivalRow?.liveEstimateTime &&
+		!isCancelled &&
+		arrivalRow?.differenceInMinutes !== undefined &&
+		(arrivalRow?.differenceInMinutes as number) > 1,
+	);
+
 	const displayedTime = useLiveEstimate
 		? (departureRow.liveEstimateTime as string)
 		: departureRow.scheduledTime;
+
+	const arrivalDisplayedTime = useArrivalLiveEstimate
+		? (arrivalRow?.liveEstimateTime as string)
+		: arrivalRow?.scheduledTime;
 
 	return (
 			<span class="text-gray-600 dark:text-gray-300 text-lg sm:text-lg whitespace-nowrap overflow-hidden text-ellipsis">
@@ -28,7 +39,12 @@ const TimeRow = ({
 					{formatTime(displayedTime)}
 				</time>
 				<span class="mx-2">→</span>
-				{arrivalRow && formatTime(arrivalRow.scheduledTime)}
+				{arrivalRow && (
+					<>
+						{useArrivalLiveEstimate && "~"}
+						{arrivalDisplayedTime && formatTime(arrivalDisplayedTime)}
+					</>
+				)}
 			</span>
 	);
 };

--- a/src/components/TimeRow.tsx
+++ b/src/components/TimeRow.tsx
@@ -23,7 +23,7 @@ const TimeRow = ({
 		!rowIsCancelled &&
 		!arrivalRow?.cancelled &&
 		arrivalRow?.differenceInMinutes !== undefined &&
-		(arrivalRow?.differenceInMinutes as number) > 1,
+		arrivalRow.differenceInMinutes > 1,
 	);
 
 	const displayedTime = useLiveEstimate

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "preact/hooks";
 import type { Train } from "../types";
 import { getRelevantTrackInfo } from "../utils/api";
 import { hapticImpact } from "../utils/haptics";
+import { getDepartureDate } from "../utils/trainUtils";
 import { t } from "../utils/translations";
 import TimeDisplay from "./TimeDisplay";
 
@@ -139,16 +140,12 @@ export default function TrainCard({
 		}
 
 		const minutesToDeparture = formatMinutesToDeparture(
-			departureRow.actualTime ??
-				departureRow.liveEstimateTime ??
-				departureRow.scheduledTime,
+			getDepartureDate(departureRow).toISOString(),
 			currentTime,
 		);
 
 		const departingSoon = isDepartingSoon(
-			departureRow.actualTime ??
-				departureRow.liveEstimateTime ??
-				departureRow.scheduledTime,
+			getDepartureDate(departureRow).toISOString(),
 			currentTime,
 		);
 
@@ -158,7 +155,9 @@ export default function TrainCard({
 			arrivalRow?.liveEstimateTime ?? arrivalRow?.scheduledTime;
 		const duration = arrivalTime
 			? calculateDuration(
-					departureRow.actualTime ?? departureRow.scheduledTime,
+					departureRow.actualTime ??
+						departureRow.liveEstimateTime ??
+						departureRow.scheduledTime,
 					arrivalTime,
 				)
 			: null;

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -13,6 +13,7 @@ interface Props {
 	destinationCode: string;
 	currentTime: Date;
 	onDepart?: () => void;
+	onReappear?: () => void;
 	getDurationSpeedType?: (
 		durationMinutes: number,
 	) => "fast" | "slow" | "normal";
@@ -94,6 +95,7 @@ export default function TrainCard({
 	destinationCode,
 	currentTime,
 	onDepart,
+	onReappear,
 	getDurationSpeedType,
 }: Props) {
 	const [, setLanguageChange] = useState(0);
@@ -206,8 +208,9 @@ export default function TrainCard({
 			// Estimation jumped forward; bring card back
 			setHasDeparted(false);
 			setOpacity(1);
+			onReappear?.();
 		}
-	}, [minutesToDeparture, hasDeparted, onDepart]);
+	}, [minutesToDeparture, hasDeparted, onDepart, onReappear]);
 
 	useEffect(() => {
 		// Load highlighted state from localStorage

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -155,9 +155,7 @@ export default function TrainCard({
 			arrivalRow?.liveEstimateTime ?? arrivalRow?.scheduledTime;
 		const duration = arrivalTime
 			? calculateDuration(
-					departureRow.actualTime ??
-						departureRow.liveEstimateTime ??
-						departureRow.scheduledTime,
+					getDepartureDate(departureRow).toISOString(),
 					arrivalTime,
 				)
 			: null;

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -192,17 +192,20 @@ export default function TrainCard({
 		getDurationSpeedType,
 	]);
 
-	// Call onDepart when the train transitions from not departed to departed
+	// Handle depart/unde-part transitions when estimate jumps forward
 	useEffect(() => {
-		if (!minutesToDeparture) return;
+		if (minutesToDeparture === null) return;
 		if (minutesToDeparture < 0 && !hasDeparted) {
 			setHasDeparted(true);
 			setOpacity(1);
-			// Start fade out
 			requestAnimationFrame(() => {
 				setOpacity(0);
 			});
 			onDepart?.();
+		} else if (minutesToDeparture >= 0 && hasDeparted) {
+			// Estimation jumped forward; bring card back
+			setHasDeparted(false);
+			setOpacity(1);
 		}
 	}, [minutesToDeparture, hasDeparted, onDepart]);
 

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -197,15 +197,14 @@ export default function TrainCard({
 	// Handle depart/unde-part transitions when estimate jumps forward
 	useEffect(() => {
 		if (minutesToDeparture === null) return;
-		// Always cancel any pending RAF before scheduling a new one
-		if (fadeRafRef.current !== null) {
-			cancelAnimationFrame(fadeRafRef.current);
-			fadeRafRef.current = null;
-		}
-
 		if (minutesToDeparture < 0 && !hasDeparted) {
 			setHasDeparted(true);
 			setOpacity(1);
+			// Cancel any previous fade RAF just before scheduling a new one
+			if (fadeRafRef.current !== null) {
+				cancelAnimationFrame(fadeRafRef.current);
+				fadeRafRef.current = null;
+			}
 			fadeRafRef.current = requestAnimationFrame(() => {
 				setOpacity(0);
 			});

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -24,6 +24,13 @@ interface Props {
 	) => "fast" | "slow" | "normal";
 }
 
+type HighlightedTrainData = {
+    highlighted?: boolean;
+    removeAfter?: string;
+    track?: string;
+    trackChanged?: boolean;
+};
+
 const formatMinutesToDeparture = (departure: Date, currentTime: Date) => {
 	const diffMs = departure.getTime() - currentTime.getTime();
 	const diffMinutes = diffMs / (1000 * 60);
@@ -218,7 +225,7 @@ export default function TrainCard({
 
 	useEffect(() => {
 		// Load highlighted state from localStorage (safe parse)
-		let highlightedTrains: Record<string, any>;
+		let highlightedTrains: Record<string, HighlightedTrainData>;
 		try {
 			highlightedTrains = JSON.parse(
 				localStorage.getItem("highlightedTrains") || "{}",
@@ -397,7 +404,7 @@ export default function TrainCard({
 		setIsHighlighted(newHighlighted);
 
 		// Update localStorage (safe parse)
-		let highlightedTrains: Record<string, any>;
+		let highlightedTrains: Record<string, HighlightedTrainData>;
 		try {
 			highlightedTrains = JSON.parse(
 				localStorage.getItem("highlightedTrains") || "{}",

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -137,12 +137,16 @@ export default function TrainCard({
 		}
 
 		const minutesToDeparture = formatMinutesToDeparture(
-			departureRow.liveEstimateTime ?? departureRow.scheduledTime,
+			departureRow.actualTime ??
+				departureRow.liveEstimateTime ??
+				departureRow.scheduledTime,
 			currentTime,
 		);
 
 		const departingSoon = isDepartingSoon(
-			departureRow.liveEstimateTime ?? departureRow.scheduledTime,
+			departureRow.actualTime ??
+				departureRow.liveEstimateTime ??
+				departureRow.scheduledTime,
 			currentTime,
 		);
 

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -14,6 +14,10 @@ interface Props {
 	destinationCode: string;
 	currentTime: Date;
 	onDepart?: () => void;
+	/**
+	 * Called when a train that had been considered departed becomes non-departed again
+	 * due to its estimate moving back to now or the future (minutesToDeparture >= 0).
+	 */
 	onReappear?: () => void;
 	getDurationSpeedType?: (
 		durationMinutes: number,
@@ -365,9 +369,7 @@ export default function TrainCard({
 			);
 
 			if (departureRow) {
-				const departureTime = new Date(
-					departureRow.liveEstimateTime ?? departureRow.scheduledTime,
-				);
+				const departureTime = getDepartureDate(departureRow);
 				const removeAfter = new Date(departureTime.getTime() + 10 * 60 * 1000); // 10 minutes after departure
 
 				highlightedTrains[train.trainNumber] = {

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -237,6 +237,14 @@ export default function TrainList({
 		}, FADE_DURATION);
 	}, []);
 
+	const handleTrainReappear = useCallback((trainNumber: string) => {
+		setDepartedTrains((prev) => {
+			const next = new Set(prev);
+			next.delete(trainNumber);
+			return next;
+		});
+	}, []);
+
 	useEffect(() => {
 		let startTime: number;
 		let animationFrame: number;
@@ -367,6 +375,9 @@ export default function TrainList({
 
 	const displayedTrains = (state.trains || [])
 		.filter((train) => {
+			// Filter out trains that have been manually marked as departed (post-fade)
+			if (departedTrains.has(train.trainNumber)) return false;
+
 			// Filter out trains that have actually departed (departed more than 2 minutes ago)
 			const departureRow = train.timeTableRows.find(
 				(row) => row.stationShortCode === stationCode && row.type === "DEPARTURE",
@@ -434,6 +445,7 @@ export default function TrainList({
 								destinationCode={destinationCode}
 								currentTime={currentTime}
 								onDepart={() => handleTrainDeparted(train.trainNumber)}
+								onReappear={() => handleTrainReappear(train.trainNumber)}
 								getDurationSpeedType={getDurationSpeedType}
 							/>
 						</div>

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -27,6 +27,7 @@ interface Props {
 const MemoizedTrainCard = memo(TrainCard);
 const INITIAL_TRAIN_COUNT = 15;
 const FADE_DURATION = 3000; // 3 seconds to match the animation duration
+const DEPARTED_GRACE_MINUTES = -2; // How long to keep showing a train after departure
 
 // Adaptive refresh intervals
 const REFRESH_INTERVALS = {
@@ -384,8 +385,8 @@ export default function TrainList({
 					(departureTime.getTime() - currentTime.getTime()) / (1000 * 60),
 				);
 
-				// Don't show trains that departed more than 2 minutes ago
-				return minutesToDeparture > -2;
+				// Don't show trains that departed more than the grace period ago
+				return minutesToDeparture > DEPARTED_GRACE_MINUTES;
 			}
 
 			return true;

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -367,9 +367,6 @@ export default function TrainList({
 
 	const displayedTrains = (state.trains || [])
 		.filter((train) => {
-			// Filter out trains that have been manually marked as departed
-			if (departedTrains.has(train.trainNumber)) return false;
-
 			// Filter out trains that have actually departed (departed more than 2 minutes ago)
 			const departureRow = train.timeTableRows.find(
 				(row) => row.stationShortCode === stationCode && row.type === "DEPARTURE",
@@ -422,7 +419,7 @@ export default function TrainList({
 						<div
 							key={train.trainNumber}
 							class={`transition-[transform,opacity] duration-700 ease-in-out hover-lift ${
-								departedTrains.has(train.trainNumber.toString())
+								departedTrains.has(train.trainNumber)
 									? "animate-train-depart"
 									: "animate-scale-in"
 							}`}

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -376,7 +376,9 @@ export default function TrainList({
 
 			if (departureRow) {
 				const departureTime = new Date(
-					departureRow.liveEstimateTime ?? departureRow.scheduledTime,
+					departureRow.actualTime ??
+						departureRow.liveEstimateTime ??
+						departureRow.scheduledTime,
 				);
 				const minutesToDeparture = Math.floor(
 					(departureTime.getTime() - currentTime.getTime()) / (1000 * 60),

--- a/src/components/__tests__/TimeDisplay.test.tsx
+++ b/src/components/__tests__/TimeDisplay.test.tsx
@@ -4,7 +4,7 @@ import type { Train } from "../../types";
 import TimeDisplay from "../TimeDisplay";
 
 // Mock translations
-vi.mock("../utils/translations", () => ({
+vi.mock("../../utils/translations", () => ({
 	t: (key: string) => {
 		const translations: Record<string, string> = {
 			late: "Myöhässä",
@@ -17,7 +17,7 @@ vi.mock("../utils/translations", () => ({
 }));
 
 // Mock useLanguageChange hook
-vi.mock("../hooks/useLanguageChange", () => ({
+vi.mock("../../hooks/useLanguageChange", () => ({
 	useLanguageChange: vi.fn(),
 }));
 

--- a/src/components/__tests__/TimeDisplay.test.tsx
+++ b/src/components/__tests__/TimeDisplay.test.tsx
@@ -65,7 +65,7 @@ describe("TimeDisplay", () => {
 	};
 
 	it("renders on-time train correctly", () => {
-		const { container } = render(
+		const { getByText } = render(
 			<TimeDisplay
 				departureRow={mockDepartureRow}
 				arrivalRow={mockArrivalRow}
@@ -73,7 +73,9 @@ describe("TimeDisplay", () => {
 			/>,
 		);
 
-		expect(container).toMatchSnapshot();
+		// Should show scheduled departure and arrival without tildes
+		getByText("12.00");
+		getByText("13.00");
 	});
 
 	it("renders delayed train correctly", () => {

--- a/src/components/__tests__/TimeRow.test.tsx
+++ b/src/components/__tests__/TimeRow.test.tsx
@@ -113,4 +113,19 @@ describe("TimeRow", () => {
 
 		expect(queryByText("~")).not.toBeInTheDocument();
 	});
+
+	it("shows tilde and uses live estimate for delayed arrival >1 min", () => {
+		const delayedArrivalRow = {
+			...mockArrivalRow,
+			liveEstimateTime: "2024-03-20T11:10:00.000Z",
+			differenceInMinutes: 10,
+		};
+
+		const { getByText } = render(
+			<TimeRow departureRow={mockDepartureRow} arrivalRow={delayedArrivalRow} />,
+		);
+
+		// combined arrival display contains tilde and 13.10
+		getByText((content) => /~\s*13\.10/.test(content));
+	});
 });

--- a/src/components/__tests__/TimeRow.test.tsx
+++ b/src/components/__tests__/TimeRow.test.tsx
@@ -121,11 +121,14 @@ describe("TimeRow", () => {
 			differenceInMinutes: 10,
 		};
 
-		const { getByText } = render(
+		const { getByText, container } = render(
 			<TimeRow departureRow={mockDepartureRow} arrivalRow={delayedArrivalRow} />,
 		);
 
-		// combined arrival display contains tilde and 13.10
-		getByText((content) => /~\s*13\.10/.test(content));
+		// arrival formatted time should reflect 11:10 instead of 11:00
+		getByText("13.10");
+		// tilde is rendered as aria-hidden
+		const hiddenTilde = container.querySelector('span[aria-hidden="true"]');
+		expect(hiddenTilde).not.toBeNull();
 	});
 });

--- a/src/components/__tests__/TrainCard.test.tsx
+++ b/src/components/__tests__/TrainCard.test.tsx
@@ -228,4 +228,25 @@ describe("TrainCard", () => {
 
 		expect(getByText("+15 min")).toBeInTheDocument();
 	});
+
+	it("restores card when estimate jumps forward after being negative", () => {
+		const pastTime = new Date("2024-03-20T10:01:00.000Z");
+		const { rerender, container } = render(
+			<TrainCard {...defaultProps} currentTime={pastTime} />,
+		);
+
+		// Departure should have triggered
+		expect(defaultProps.onDepart).toHaveBeenCalled();
+
+		// Estimate jumps forward: set current time back to before departure
+		rerender(
+			<TrainCard
+				{...defaultProps}
+				currentTime={new Date("2024-03-20T09:59:00.000Z")}
+			/>,
+		);
+
+		// Card should be visible again
+		expect(container.firstChild).toHaveStyle("opacity: 1");
+	});
 });

--- a/src/components/__tests__/__snapshots__/TimeDisplay.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TimeDisplay.test.tsx.snap
@@ -8,17 +8,11 @@ exports[`TimeDisplay > renders without arrival row 1`] = `
     <span
       class="block w-full text-gray-600 dark:text-gray-300 text-base sm:text-lg whitespace-nowrap"
     >
-       
       <time
         datetime="2024-03-20T10:00:00.000Z"
       >
         12.00
       </time>
-      <span
-        class="mx-1 sm:mx-2"
-      >
-        →
-      </span>
     </span>
   </span>
 </div>

--- a/src/components/__tests__/__snapshots__/TimeDisplay.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TimeDisplay.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TimeDisplay > renders without arrival row 1`] = `
     class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-gray-100 min-w-0 relative pt-8 sm:pt-6"
   >
     <span
-      class="text-gray-600 dark:text-gray-300 text-lg sm:text-lg whitespace-nowrap overflow-hidden text-ellipsis"
+      class="block w-full text-gray-600 dark:text-gray-300 text-base sm:text-lg whitespace-nowrap"
     >
        
       <time
@@ -15,7 +15,7 @@ exports[`TimeDisplay > renders without arrival row 1`] = `
         12.00
       </time>
       <span
-        class="mx-2"
+        class="mx-1 sm:mx-2"
       >
         →
       </span>

--- a/src/components/__tests__/__snapshots__/TimeDisplay.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TimeDisplay.test.tsx.snap
@@ -1,30 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TimeDisplay > renders on-time train correctly 1`] = `
-<div>
-  <span
-    class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-gray-100 min-w-0 relative pt-8 sm:pt-6"
-  >
-    <span
-      class="text-gray-600 dark:text-gray-300 text-lg sm:text-lg whitespace-nowrap overflow-hidden text-ellipsis"
-    >
-       
-      <time
-        datetime="2024-03-20T10:00:00.000Z"
-      >
-        12.00
-      </time>
-      <span
-        class="mx-2"
-      >
-        →
-      </span>
-      13.00
-    </span>
-  </span>
-</div>
-`;
-
 exports[`TimeDisplay > renders without arrival row 1`] = `
 <div>
   <span

--- a/src/utils/trainUtils.ts
+++ b/src/utils/trainUtils.ts
@@ -7,10 +7,14 @@ export const formatTime = (date: string) => {
 	});
 };
 
-export const calculateDuration = (start: string, end: string): Duration => {
-	const durationMinutes = Math.round(
-		(new Date(end).getTime() - new Date(start).getTime()) / (1000 * 60),
-	);
+export const calculateDuration = (
+	start: Date | string,
+	end: Date | string,
+): Duration => {
+	const startMs =
+		typeof start === "string" ? new Date(start).getTime() : start.getTime();
+	const endMs = typeof end === "string" ? new Date(end).getTime() : end.getTime();
+	const durationMinutes = Math.round((endMs - startMs) / (1000 * 60));
 	return {
 		hours: Math.floor(durationMinutes / 60),
 		minutes: durationMinutes % 60,
@@ -21,4 +25,8 @@ export const getDepartureDate = (row: Train["timeTableRows"][0]): Date => {
 	return new Date(
 		row.actualTime ?? row.liveEstimateTime ?? row.scheduledTime,
 	);
+};
+
+export const getArrivalDate = (row: Train["timeTableRows"][0]): Date => {
+	return new Date(row.liveEstimateTime ?? row.scheduledTime);
 };

--- a/src/utils/trainUtils.ts
+++ b/src/utils/trainUtils.ts
@@ -1,4 +1,4 @@
-import type { Duration } from "../types";
+import type { Duration, Train } from "../types";
 
 export const formatTime = (date: string) => {
 	return new Date(date).toLocaleTimeString("fi-FI", {
@@ -15,4 +15,10 @@ export const calculateDuration = (start: string, end: string): Duration => {
 		hours: Math.floor(durationMinutes / 60),
 		minutes: durationMinutes % 60,
 	};
+};
+
+export const getDepartureDate = (row: Train["timeTableRows"][0]): Date => {
+	return new Date(
+		row.actualTime ?? row.liveEstimateTime ?? row.scheduledTime,
+	);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Train cards can restore visibility when timing estimates move from departed back to upcoming; arrival times show a leading “~” for significant live delays.

- Style
  - Tighter lateness badge and refined spacing/typography in time rows; canceled rows consistently show strike-through and hide lateness.

- Bug Fixes
  - More consistent departure/visibility calculations and faster card fade for clearer just‑departed behavior.

- Tests
  - Added/updated tests for arrival tilde, reappearance behavior, and precise time rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->