### PR TITLE
feat: conditionally load counter.dev script only in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lahijunat-live",
-	"version": "1.10.1-beta.2",
+	"version": "1.10.1-beta.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lahijunat-live",
-			"version": "1.10.1-beta.2",
+			"version": "1.10.1-beta.3",
 			"dependencies": {
 				"@astrojs/markdown-component": "^1.0.5",
 				"@astrojs/preact": "^4.1.0",
@@ -27,7 +27,7 @@
 				"@testing-library/jest-dom": "^6.8.0",
 				"@testing-library/preact": "^3.2.4",
 				"@types/node": "^24.3.0",
-				"daisyui": "^5.0.50",
+				"daisyui": "^5.0.51",
 				"jsdom": "^26.1.0",
 				"vitest": "^3.2.4",
 				"workbox-cli": "^7.3.0"
@@ -5420,9 +5420,9 @@
 			}
 		},
 		"node_modules/daisyui": {
-			"version": "5.0.50",
-			"resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.50.tgz",
-			"integrity": "sha512-c1PweK5RI1C76q58FKvbS4jzgyNJSP6CGTQ+KkZYzADdJoERnOxFoeLfDHmQgxLpjEzlYhFMXCeodQNLCC9bow==",
+			"version": "5.0.51",
+			"resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.51.tgz",
+			"integrity": "sha512-lhB0BBOjt43/t5S1my0XChMy3ClXfmGlDU/XmSlx+N0h2y7cyWF+cnheeemguxNHb9TjqI66mxKI9qiFsOU3mA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lahijunat-live",
 	"type": "module",
-	"version": "1.10.1-beta.2",
+	"version": "1.10.1-beta.3",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build && cp src/sw-utils.js dist/ && workbox generateSW workbox-config.cjs",
@@ -35,7 +35,7 @@
 		"@testing-library/jest-dom": "^6.8.0",
 		"@testing-library/preact": "^3.2.4",
 		"@types/node": "^24.3.0",
-		"daisyui": "^5.0.50",
+		"daisyui": "^5.0.51",
 		"jsdom": "^26.1.0",
 		"vitest": "^3.2.4",
 		"workbox-cli": "^7.3.0"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -158,13 +158,18 @@ const ogLocale = isEnglish ? "en_US" : "fi_FI";
         document.documentElement.setAttribute("data-theme", "light");
       }
     </script>
-    {import.meta.env.PROD && (
-      <script
-        src="https://cdn.counter.dev/script.js"
-        data-id="da3ed73f-eedb-4dd0-acac-8e7366f8508e"
-        data-utcoffset="2"></script>
-    )}
-
+         {
+       import.meta.env.PROD &&
+         Astro.site &&
+         new URL(Astro.site).hostname.endsWith("lahijunat.live") && (
+           <script
+             defer
+             src="https://cdn.counter.dev/script.js"
+             data-id="da3ed73f-eedb-4dd0-acac-8e7366f8508e"
+             data-utcoffset={new Date().getTimezoneOffset() / -60}
+           />
+         )
+     }
   </head>
   <body class="min-h-screen bg-base-100">
     <div class="min-h-screen flex flex-col">
@@ -251,7 +256,6 @@ const ogLocale = isEnglish ? "en_US" : "fi_FI";
     <script>
       const themeToggleBtn = document.getElementById("theme-toggle");
       const themeToggleInput = themeToggleBtn?.querySelector("input");
-
 
       const updateTheme = (theme: "light" | "dark") => {
         if (theme === "dark") {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -158,10 +158,12 @@ const ogLocale = isEnglish ? "en_US" : "fi_FI";
         document.documentElement.setAttribute("data-theme", "light");
       }
     </script>
-    <script
-      src="https://cdn.counter.dev/script.js"
-      data-id="da3ed73f-eedb-4dd0-acac-8e7366f8508e"
-      data-utcoffset="2"></script>
+    {import.meta.env.PROD && (
+      <script
+        src="https://cdn.counter.dev/script.js"
+        data-id="da3ed73f-eedb-4dd0-acac-8e7366f8508e"
+        data-utcoffset="2"></script>
+    )}
 
   </head>
   <body class="min-h-screen bg-base-100">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted analytics to load only in production environments. This prevents unnecessary network requests and side effects during development, improving local performance and privacy.
  * Production behavior remains unchanged; end users will see no functional differences. This helps keep metrics clean by avoiding test traffic and development noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->