### PR TITLE
feat: modify mobile accordion to close only when TO station is selected

### DIFF
--- a/src/components/StationManager.tsx
+++ b/src/components/StationManager.tsx
@@ -88,9 +88,10 @@ export default function StationManager({
 	const isSwappingRef = useRef(false);
 	const lastSwapTimeRef = useRef(0);
 
-	// Mobile accordion state - expanded by default if no stations selected
-	// On mobile: accordion closes only when TO station is selected
-	// On desktop: accordion is always open (sm:collapse-open)
+// Mobile accordion state
+// Expanded by default if either origin or destination is missing
+// On mobile: accordion auto-closes only when "to" station is selected
+// On desktop: accordion is always open via sm:collapse-open
 	const [isStationSelectorExpanded, setIsStationSelectorExpanded] = useState(
 		!initialFromStation || !initialToStation,
 	);
@@ -102,7 +103,9 @@ export default function StationManager({
 	useLanguageChange();
 
 	// Smart accordion toggle logic
-	useEffect(() => {
+  useEffect(() => {
+	// Ignore transient swaps to avoid flicker
+	if (isSwapping) return;
 		// On mobile: only auto-collapse when TO station is selected (not when FROM is selected)
 		// On desktop: accordion is always open, so this doesn't matter
 		if (selectedDestination) {
@@ -112,7 +115,7 @@ export default function StationManager({
 		else if (!selectedOrigin && !selectedDestination) {
 			setIsStationSelectorExpanded(true);
 		}
-	}, [selectedOrigin, selectedDestination]);
+	}, [selectedOrigin, selectedDestination, isSwapping]);
 
 	// Auto-focus "to" input when "from" is selected and "to" is empty
 	useEffect(() => {
@@ -285,6 +288,8 @@ export default function StationManager({
 	const handleDestinationSelect = (station: Station) => {
 		setSelectedDestination(station.shortCode);
 		setStoredValue("selectedDestination", station.shortCode);
+		// Close the dropdown after selection
+		setOpenList(null);
 	};
 
 	const handleLocationRequest = async () => {


### PR DESCRIPTION
- Change accordion behavior on mobile so it stays open when FROM station changes
- Accordion now only auto-closes when TO station is selected
- Maintains existing desktop behavior (always open)
- Improves mobile UX by keeping station selector visible during route planning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mobile accordion now auto-collapses when a destination is selected and auto-expands when neither origin nor destination is set.
  - Desktop accordion remains open for easier access.

- **Bug Fixes**
  - Prevents flicker during quick origin/destination swaps.
  - Destination list now closes automatically after selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->