### PR TITLE
fix: prevent station dropdown from shifting adjacent buttons

### DIFF
--- a/src/components/StationList.tsx
+++ b/src/components/StationList.tsx
@@ -208,13 +208,10 @@ export default function StationList({
 		return () => clearTimeout(timer);
 	}, [filteredStations.length, isOpen, searchTerm, langToken]);
 
-	// Dynamic min-height so the container shortens when there are few results
 	const filteredCount = filteredStations.length;
-	const rootMinHeightClass =
-		isOpen && (isLoading || filteredCount >= 5) ? "min-h-[16rem]" : "";
 
 	return (
-		<div className={`relative station-list-container ${rootMinHeightClass}`}>
+		<div className="relative station-list-container">
 			<input
 				ref={finalInputRef}
 				type="text"
@@ -259,7 +256,7 @@ export default function StationList({
 					id={listboxId}
 					data-testid="station-listbox"
 					role="listbox"
-					className={`menu bg-base-100 rounded-box w-full mt-2 ${
+					className={`menu bg-base-100 rounded-box w-full mt-2 border border-base-content/30 ${
 						isLoading || filteredCount >= 5 ? "min-h-[12rem]" : ""
 					} max-h-[50vh] sm:max-h-60 overflow-y-auto flex-nowrap shadow-xl z-50 animate-slide-down`}
 					style={{

--- a/src/components/StationManager.tsx
+++ b/src/components/StationManager.tsx
@@ -704,7 +704,7 @@ export default function StationManager({
 							>
 								{t("from")}
 							</h3>
-							<div className="flex flex-row-reverse items-center gap-2">
+							<div className="flex flex-row-reverse items-start gap-2">
 								<div className="flex">
 									<button
 										type="button"

--- a/src/components/StationOption.tsx
+++ b/src/components/StationOption.tsx
@@ -31,7 +31,7 @@ function StationOption({
 			role="option"
 			aria-selected={isSelected}
 			class={`btn btn-ghost justify-start normal-case btn-block text-left text-lg sm:text-base min-h-[48px] station-option transition-colors duration-200 touch-manipulation select-none focus-ring ${
-				isHighlighted ? "bg-blue-100 animate-scale-in" : ""
+				isHighlighted ? "bg-blue-100 dark:bg-blue-900/40 animate-scale-in" : ""
 			}`}
 		>
 			{getLocalizedStationName(station.name, station.shortCode)} (


### PR DESCRIPTION
## Summary
- Anchor From row buttons to the top of the flex row (`items-start`) and remove the forced 16rem min-height so opening the station dropdown no longer shifts the locate/swap buttons next to it
- Add a visible border on the listbox so the dropdown edge is clearly separated from the page background
- Give the arrow-key highlight a dark-mode color (`dark:bg-blue-900/40`) so the selected option stays readable on dark themes

## Test plan
- [ ] Open the From dropdown on desktop — locate/swap buttons stay anchored next to the input
- [ ] Open the To dropdown — no layout shift
- [ ] Arrow-navigate through options in dark mode — highlighted row is legible
- [ ] Dropdown border is visible against the page background in both light and dark mode
- [ ] `pnpm run typecheck` and `pnpm run test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dropdown container with improved border styling for better visual definition
  * Refined vertical alignment of station controls for improved layout consistency
  * Improved dark mode highlighting for station options to provide better visual feedback during selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikosalonen/lahijunat.live/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->