### PR TITLE
feat: show Digitraffic passenger information messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lahijunat-live",
 	"type": "module",
-	"version": "1.14.1",
+	"version": "1.15.0",
 	"packageManager": "pnpm@11.0.8",
 	"engines": {
 		"node": ">=24"

--- a/src/__tests__/fixtures/passengerInfo.ts
+++ b/src/__tests__/fixtures/passengerInfo.ts
@@ -1,0 +1,94 @@
+/** @format */
+/**
+ * Hand-rolled passenger-information fixtures for manual visual checks and
+ * unit tests. The shapes mirror the live `/v1/passenger-information/active`
+ * payload but only the video channel is populated (the feature is video-only).
+ */
+
+import type { PassengerInformationMessage } from "../../utils/passengerInfo";
+
+const ALL_DAYS = [
+	"MONDAY",
+	"TUESDAY",
+	"WEDNESDAY",
+	"THURSDAY",
+	"FRIDAY",
+	"SATURDAY",
+	"SUNDAY",
+] as const;
+
+export const generalContinuousMessage: PassengerInformationMessage = {
+	id: "general-continuous-1",
+	startValidity: "2026-05-03T00:00:00Z",
+	endValidity: "2026-09-06T23:59:59Z",
+	trainNumber: null,
+	trainDepartureDate: null,
+	stations: ["MLO"],
+	video: {
+		text: {
+			fi: "Malminkartanon asema on suljettu 3.5.–6.9. kunnostustöiden vuoksi.",
+			sv: "Malmgårds station är stängd 3.5.–6.9. på grund av reparationsarbeten.",
+			en: "Malminkartano station is closed 3 May – 6 Sept for renovation works.",
+		},
+		deliveryRules: {
+			deliveryType: "CONTINUOS_VISUALIZATION",
+			startDateTime: "2026-05-03T00:00:00Z",
+			endDateTime: "2026-09-06T23:59:59Z",
+			weekDays: [...ALL_DAYS],
+		},
+	},
+};
+
+export const generalWindowedMessage: PassengerInformationMessage = {
+	id: "general-window-1",
+	startValidity: "2026-05-01T00:00:00Z",
+	endValidity: "2026-12-31T23:59:59Z",
+	trainNumber: null,
+	trainDepartureDate: null,
+	stations: ["HKI"],
+	video: {
+		text: {
+			fi: "Kehäradan ratatöiden vuoksi junat saattavat olla myöhässä.",
+			sv: null,
+			en: "Trackwork on the Ring Rail may cause delays.",
+		},
+		deliveryRules: {
+			deliveryType: "WHEN",
+			startDateTime: "2026-05-01T00:00:00Z",
+			endDateTime: "2026-12-31T23:59:59Z",
+			startTime: "7:10",
+			endTime: "22:00",
+			weekDays: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+		},
+	},
+};
+
+export const perTrainMessage: PassengerInformationMessage = {
+	id: "train-1234-1",
+	startValidity: "2026-05-28T05:00:00Z",
+	endValidity: "2026-05-28T20:00:00Z",
+	trainNumber: 1234,
+	trainDepartureDate: "2026-05-28",
+	stations: ["HKI", "PSL"],
+	video: {
+		text: {
+			fi: "Junassa 1234 on ravintolavaunu poikkeuksellisesti suljettu.",
+			sv: null,
+			en: "Train 1234's restaurant car is closed today.",
+		},
+		deliveryRules: {
+			deliveryType: "WHEN",
+			startDateTime: "2026-05-28T05:00:00Z",
+			endDateTime: "2026-05-28T20:00:00Z",
+			startTime: "8:00",
+			endTime: "22:00",
+			weekDays: [...ALL_DAYS],
+		},
+	},
+};
+
+export const allFixtures: PassengerInformationMessage[] = [
+	generalContinuousMessage,
+	generalWindowedMessage,
+	perTrainMessage,
+];

--- a/src/components/PassengerInfoBanner.tsx
+++ b/src/components/PassengerInfoBanner.tsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import { useCallback, useEffect, useState } from "preact/hooks";
+import { useCallback, useEffect, useId, useState } from "preact/hooks";
 import type { ActiveMessage } from "../utils/passengerInfo";
 import { t } from "../utils/translations";
 import PassengerInfoCarousel from "./PassengerInfoCarousel";
@@ -71,6 +71,7 @@ export default function PassengerInfoBanner({ messages }: Props) {
 	const [expanded, setExpanded] = useState(false);
 	const [pref, setPref] = useState<PassengerInfoPref | null>(() => readPref());
 	const [promptOpen, setPromptOpen] = useState(false);
+	const panelId = useId();
 
 	const snoozed = isSnoozed(pref, Date.now());
 
@@ -144,6 +145,7 @@ export default function PassengerInfoBanner({ messages }: Props) {
 					type="button"
 					class="flex-1 flex items-center gap-3 px-4 py-3 text-left min-w-0"
 					aria-expanded={expanded}
+					aria-controls={panelId}
 					onClick={() => setExpanded((v) => !v)}
 				>
 					<svg
@@ -241,7 +243,10 @@ export default function PassengerInfoBanner({ messages }: Props) {
 				</div>
 			)}
 			{expanded && !promptOpen && (
-				<div class="px-4 pb-4 pt-1 border-t border-amber-200/60 dark:border-amber-900/40">
+				<div
+					id={panelId}
+					class="px-4 pb-4 pt-1 border-t border-amber-200/60 dark:border-amber-900/40"
+				>
 					<PassengerInfoCarousel messages={messages} />
 				</div>
 			)}

--- a/src/components/PassengerInfoBanner.tsx
+++ b/src/components/PassengerInfoBanner.tsx
@@ -10,7 +10,12 @@ interface Props {
 }
 
 const PREF_STORAGE_KEY = "passengerInfoPref";
-const DAY_MS = 24 * 60 * 60 * 1000;
+
+function endOfLocalDay(now: number): number {
+	const d = new Date(now);
+	d.setHours(24, 0, 0, 0);
+	return d.getTime();
+}
 
 type PassengerInfoPref =
 	| { mode: "never" }
@@ -59,11 +64,11 @@ function isSnoozed(pref: PassengerInfoPref | null, now: number): boolean {
  * Dismissal flow:
  * - First time the user clicks ×, an inline confirm row asks whether to
  *   show announcements again later. "Never" hides them permanently; "Hide
- *   for today" snoozes them for 24h.
+ *   for today" snoozes them until the next local midnight.
  * - On subsequent closes the previous choice is applied silently — for the
- *   "daily" mode, that means re-arming the 24h snooze without re-prompting.
- *   For "never" the banner never reappears in the first place, so there is
- *   nothing more to click.
+ *   "daily" mode, that means re-arming the until-midnight snooze without
+ *   re-prompting. For "never" the banner never reappears in the first
+ *   place, so there is nothing more to click.
  *
  * Choice persists in localStorage under `passengerInfoPref`.
  */
@@ -103,7 +108,7 @@ export default function PassengerInfoBanner({ messages }: Props) {
 		if (pref.mode === "daily") {
 			const next: PassengerInfoPref = {
 				mode: "daily",
-				snoozedUntil: Date.now() + DAY_MS,
+				snoozedUntil: endOfLocalDay(Date.now()),
 			};
 			writePref(next);
 			setPref(next);
@@ -122,7 +127,7 @@ export default function PassengerInfoBanner({ messages }: Props) {
 	const chooseDaily = useCallback(() => {
 		const next: PassengerInfoPref = {
 			mode: "daily",
-			snoozedUntil: Date.now() + DAY_MS,
+			snoozedUntil: endOfLocalDay(Date.now()),
 		};
 		writePref(next);
 		setPref(next);

--- a/src/components/PassengerInfoBanner.tsx
+++ b/src/components/PassengerInfoBanner.tsx
@@ -1,0 +1,78 @@
+/** @format */
+
+import { useState } from "preact/hooks";
+import type { ActiveMessage } from "../utils/passengerInfo";
+import { t } from "../utils/translations";
+import PassengerInfoCarousel from "./PassengerInfoCarousel";
+
+interface Props {
+	messages: ActiveMessage[];
+}
+
+/**
+ * Banner above the train list that surfaces general passenger-information
+ * announcements (messages with `trainNumber === null`). Collapsed by default;
+ * expands to reveal the message text (or a carousel when multiple are active).
+ */
+export default function PassengerInfoBanner({ messages }: Props) {
+	const [expanded, setExpanded] = useState(false);
+
+	if (messages.length === 0) return null;
+
+	const count = messages.length;
+
+	return (
+		<section
+			class="rounded-xl border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-900/60 shadow-sm"
+			aria-label={t("passengerInfoBannerTitle")}
+		>
+			<button
+				type="button"
+				class="w-full flex items-center gap-3 px-4 py-3 text-left"
+				aria-expanded={expanded}
+				onClick={() => setExpanded((v) => !v)}
+			>
+				<svg
+					class="w-5 h-5 flex-shrink-0 text-amber-600 dark:text-amber-400"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<circle cx="12" cy="12" r="10" />
+					<line x1="12" y1="8" x2="12" y2="12" />
+					<line x1="12" y1="16" x2="12.01" y2="16" />
+				</svg>
+				<span class="flex-1 font-medium text-gray-800 dark:text-gray-100">
+					{t("passengerInfoBannerTitle")}
+					<span class="ml-2 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-amber-200 dark:bg-amber-800 text-xs text-amber-900 dark:text-amber-100">
+						{count}
+					</span>
+				</span>
+				<svg
+					class={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<polyline points="6 9 12 15 18 9" />
+				</svg>
+				<span class="sr-only">
+					{expanded ? t("passengerInfoCollapse") : t("passengerInfoExpand")}
+				</span>
+			</button>
+			{expanded && (
+				<div class="px-4 pb-4 pt-1 border-t border-amber-200/60 dark:border-amber-900/40">
+					<PassengerInfoCarousel messages={messages} />
+				</div>
+			)}
+		</section>
+	);
+}

--- a/src/components/PassengerInfoBanner.tsx
+++ b/src/components/PassengerInfoBanner.tsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import { useState } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import type { ActiveMessage } from "../utils/passengerInfo";
 import { t } from "../utils/translations";
 import PassengerInfoCarousel from "./PassengerInfoCarousel";
@@ -9,68 +9,147 @@ interface Props {
 	messages: ActiveMessage[];
 }
 
+const DISMISSED_STORAGE_KEY = "passengerInfoDismissed";
+
+function readDismissedIds(): Set<string> {
+	if (typeof window === "undefined") return new Set();
+	try {
+		const raw = window.localStorage.getItem(DISMISSED_STORAGE_KEY);
+		if (!raw) return new Set();
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return new Set();
+		return new Set(parsed.filter((v): v is string => typeof v === "string"));
+	} catch {
+		return new Set();
+	}
+}
+
+function writeDismissedIds(ids: Set<string>): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(
+			DISMISSED_STORAGE_KEY,
+			JSON.stringify(Array.from(ids)),
+		);
+	} catch {
+		// localStorage may be unavailable (private mode, quota); dismissal is
+		// best-effort and not worth surfacing an error.
+	}
+}
+
 /**
  * Banner above the train list that surfaces general passenger-information
  * announcements (messages with `trainNumber === null`). Collapsed by default;
  * expands to reveal the message text (or a carousel when multiple are active).
+ *
+ * Dismissal: a small × button on the header marks the currently-visible
+ * message IDs as dismissed in localStorage, so they stay hidden across page
+ * reloads. Messages with new IDs that the user has not seen will still appear.
  */
 export default function PassengerInfoBanner({ messages }: Props) {
 	const [expanded, setExpanded] = useState(false);
+	const [dismissedIds, setDismissedIds] = useState<Set<string>>(() =>
+		readDismissedIds(),
+	);
 
-	if (messages.length === 0) return null;
+	const visibleMessages = useMemo(
+		() => messages.filter((m) => !dismissedIds.has(m.id)),
+		[messages, dismissedIds],
+	);
 
-	const count = messages.length;
+	const dismissCurrent = useCallback(() => {
+		const next = new Set(dismissedIds);
+		for (const m of visibleMessages) next.add(m.id);
+		writeDismissedIds(next);
+		setDismissedIds(next);
+		setExpanded(false);
+	}, [dismissedIds, visibleMessages]);
+
+	// Collapse if all messages disappear (e.g. delivery window closes or every
+	// remaining message gets dismissed).
+	useEffect(() => {
+		if (visibleMessages.length === 0 && expanded) setExpanded(false);
+	}, [visibleMessages.length, expanded]);
+
+	if (visibleMessages.length === 0) return null;
+
+	const count = visibleMessages.length;
 
 	return (
 		<section
 			class="rounded-xl border border-amber-200 bg-amber-50 dark:bg-amber-950/40 dark:border-amber-900/60 shadow-sm"
 			aria-label={t("passengerInfoBannerTitle")}
 		>
-			<button
-				type="button"
-				class="w-full flex items-center gap-3 px-4 py-3 text-left"
-				aria-expanded={expanded}
-				onClick={() => setExpanded((v) => !v)}
-			>
-				<svg
-					class="w-5 h-5 flex-shrink-0 text-amber-600 dark:text-amber-400"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					aria-hidden="true"
+			<div class="w-full flex items-center gap-2 pr-2">
+				<button
+					type="button"
+					class="flex-1 flex items-center gap-3 px-4 py-3 text-left min-w-0"
+					aria-expanded={expanded}
+					onClick={() => setExpanded((v) => !v)}
 				>
-					<circle cx="12" cy="12" r="10" />
-					<line x1="12" y1="8" x2="12" y2="12" />
-					<line x1="12" y1="16" x2="12.01" y2="16" />
-				</svg>
-				<span class="flex-1 font-medium text-gray-800 dark:text-gray-100">
-					{t("passengerInfoBannerTitle")}
-					<span class="ml-2 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-amber-200 dark:bg-amber-800 text-xs text-amber-900 dark:text-amber-100">
-						{count}
+					<svg
+						class="w-5 h-5 flex-shrink-0 text-amber-600 dark:text-amber-400"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<circle cx="12" cy="12" r="10" />
+						<line x1="12" y1="8" x2="12" y2="12" />
+						<line x1="12" y1="16" x2="12.01" y2="16" />
+					</svg>
+					<span class="flex-1 font-medium text-gray-800 dark:text-gray-100 truncate">
+						{t("passengerInfoBannerTitle")}
+						<span class="ml-2 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-amber-200 dark:bg-amber-800 text-xs text-amber-900 dark:text-amber-100">
+							{count}
+						</span>
 					</span>
-				</span>
-				<svg
-					class={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${expanded ? "rotate-180" : ""}`}
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					aria-hidden="true"
+					<svg
+						class={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<polyline points="6 9 12 15 18 9" />
+					</svg>
+					<span class="sr-only">
+						{expanded ? t("passengerInfoCollapse") : t("passengerInfoExpand")}
+					</span>
+				</button>
+				<button
+					type="button"
+					class="flex-shrink-0 inline-flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 hover:bg-amber-200/70 dark:hover:bg-amber-900/60 transition-colors"
+					aria-label={t("passengerInfoDismiss")}
+					onClick={(event) => {
+						event.stopPropagation();
+						dismissCurrent();
+					}}
 				>
-					<polyline points="6 9 12 15 18 9" />
-				</svg>
-				<span class="sr-only">
-					{expanded ? t("passengerInfoCollapse") : t("passengerInfoExpand")}
-				</span>
-			</button>
+					<svg
+						class="w-4 h-4"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<line x1="18" y1="6" x2="6" y2="18" />
+						<line x1="6" y1="6" x2="18" y2="18" />
+					</svg>
+				</button>
+			</div>
 			{expanded && (
 				<div class="px-4 pb-4 pt-1 border-t border-amber-200/60 dark:border-amber-900/40">
-					<PassengerInfoCarousel messages={messages} />
+					<PassengerInfoCarousel messages={visibleMessages} />
 				</div>
 			)}
 		</section>

--- a/src/components/PassengerInfoBanner.tsx
+++ b/src/components/PassengerInfoBanner.tsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
+import { useCallback, useEffect, useState } from "preact/hooks";
 import type { ActiveMessage } from "../utils/passengerInfo";
 import { t } from "../utils/translations";
 import PassengerInfoCarousel from "./PassengerInfoCarousel";
@@ -9,71 +9,130 @@ interface Props {
 	messages: ActiveMessage[];
 }
 
-const DISMISSED_STORAGE_KEY = "passengerInfoDismissed";
+const PREF_STORAGE_KEY = "passengerInfoPref";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-function readDismissedIds(): Set<string> {
-	if (typeof window === "undefined") return new Set();
+type PassengerInfoPref =
+	| { mode: "never" }
+	| { mode: "daily"; snoozedUntil: number };
+
+function readPref(): PassengerInfoPref | null {
+	if (typeof window === "undefined") return null;
 	try {
-		const raw = window.localStorage.getItem(DISMISSED_STORAGE_KEY);
-		if (!raw) return new Set();
-		const parsed = JSON.parse(raw);
-		if (!Array.isArray(parsed)) return new Set();
-		return new Set(parsed.filter((v): v is string => typeof v === "string"));
+		const raw = window.localStorage.getItem(PREF_STORAGE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as PassengerInfoPref | null;
+		if (!parsed || typeof parsed !== "object") return null;
+		if (parsed.mode === "never") return parsed;
+		if (
+			parsed.mode === "daily" &&
+			typeof (parsed as { snoozedUntil?: unknown }).snoozedUntil === "number"
+		) {
+			return parsed;
+		}
+		return null;
 	} catch {
-		return new Set();
+		return null;
 	}
 }
 
-function writeDismissedIds(ids: Set<string>): void {
+function writePref(p: PassengerInfoPref): void {
 	if (typeof window === "undefined") return;
 	try {
-		window.localStorage.setItem(
-			DISMISSED_STORAGE_KEY,
-			JSON.stringify(Array.from(ids)),
-		);
+		window.localStorage.setItem(PREF_STORAGE_KEY, JSON.stringify(p));
 	} catch {
-		// localStorage may be unavailable (private mode, quota); dismissal is
-		// best-effort and not worth surfacing an error.
+		// localStorage may be unavailable; preference is best-effort.
 	}
+}
+
+function isSnoozed(pref: PassengerInfoPref | null, now: number): boolean {
+	if (!pref) return false;
+	if (pref.mode === "never") return true;
+	return now < pref.snoozedUntil;
 }
 
 /**
  * Banner above the train list that surfaces general passenger-information
- * announcements (messages with `trainNumber === null`). Collapsed by default;
- * expands to reveal the message text (or a carousel when multiple are active).
+ * announcements. Collapsed by default; expands to reveal the message text
+ * (or a carousel when multiple are active).
  *
- * Dismissal: a small × button on the header marks the currently-visible
- * message IDs as dismissed in localStorage, so they stay hidden across page
- * reloads. Messages with new IDs that the user has not seen will still appear.
+ * Dismissal flow:
+ * - First time the user clicks ×, an inline confirm row asks whether to
+ *   show announcements again later. "Never" hides them permanently; "Hide
+ *   for today" snoozes them for 24h.
+ * - On subsequent closes the previous choice is applied silently — for the
+ *   "daily" mode, that means re-arming the 24h snooze without re-prompting.
+ *   For "never" the banner never reappears in the first place, so there is
+ *   nothing more to click.
+ *
+ * Choice persists in localStorage under `passengerInfoPref`.
  */
 export default function PassengerInfoBanner({ messages }: Props) {
 	const [expanded, setExpanded] = useState(false);
-	const [dismissedIds, setDismissedIds] = useState<Set<string>>(() =>
-		readDismissedIds(),
-	);
+	const [pref, setPref] = useState<PassengerInfoPref | null>(() => readPref());
+	const [promptOpen, setPromptOpen] = useState(false);
 
-	const visibleMessages = useMemo(
-		() => messages.filter((m) => !dismissedIds.has(m.id)),
-		[messages, dismissedIds],
-	);
+	const snoozed = isSnoozed(pref, Date.now());
 
-	const dismissCurrent = useCallback(() => {
-		const next = new Set(dismissedIds);
-		for (const m of visibleMessages) next.add(m.id);
-		writeDismissedIds(next);
-		setDismissedIds(next);
-		setExpanded(false);
-	}, [dismissedIds, visibleMessages]);
-
-	// Collapse if all messages disappear (e.g. delivery window closes or every
-	// remaining message gets dismissed).
+	// Re-arm a render once the daily snooze expires while the page is open.
 	useEffect(() => {
-		if (visibleMessages.length === 0 && expanded) setExpanded(false);
-	}, [visibleMessages.length, expanded]);
+		if (!pref || pref.mode !== "daily") return;
+		const remaining = pref.snoozedUntil - Date.now();
+		if (remaining <= 0) return;
+		const handle = window.setTimeout(() => {
+			setPref(readPref());
+		}, remaining + 100);
+		return () => window.clearTimeout(handle);
+	}, [pref]);
 
-	if (visibleMessages.length === 0) return null;
+	// Auto-collapse if message list empties.
+	useEffect(() => {
+		if (messages.length === 0 && expanded) setExpanded(false);
+	}, [messages.length, expanded]);
 
-	const count = visibleMessages.length;
+	const onCloseClick = useCallback(() => {
+		// No prior choice → ask once.
+		if (!pref) {
+			setPromptOpen(true);
+			return;
+		}
+		// Returning user already chose. If they chose "daily" before, just
+		// re-arm the 24h snooze silently. ("never" can't reach this branch
+		// because the banner would not be visible.)
+		if (pref.mode === "daily") {
+			const next: PassengerInfoPref = {
+				mode: "daily",
+				snoozedUntil: Date.now() + DAY_MS,
+			};
+			writePref(next);
+			setPref(next);
+			setExpanded(false);
+		}
+	}, [pref]);
+
+	const chooseNever = useCallback(() => {
+		const next: PassengerInfoPref = { mode: "never" };
+		writePref(next);
+		setPref(next);
+		setPromptOpen(false);
+		setExpanded(false);
+	}, []);
+
+	const chooseDaily = useCallback(() => {
+		const next: PassengerInfoPref = {
+			mode: "daily",
+			snoozedUntil: Date.now() + DAY_MS,
+		};
+		writePref(next);
+		setPref(next);
+		setPromptOpen(false);
+		setExpanded(false);
+	}, []);
+
+	if (messages.length === 0) return null;
+	if (snoozed && !promptOpen) return null;
+
+	const count = messages.length;
 
 	return (
 		<section
@@ -129,7 +188,7 @@ export default function PassengerInfoBanner({ messages }: Props) {
 					aria-label={t("passengerInfoDismiss")}
 					onClick={(event) => {
 						event.stopPropagation();
-						dismissCurrent();
+						onCloseClick();
 					}}
 				>
 					<svg
@@ -147,9 +206,43 @@ export default function PassengerInfoBanner({ messages }: Props) {
 					</svg>
 				</button>
 			</div>
-			{expanded && (
+			{promptOpen && (
+				<div
+					class="px-4 py-3 border-t border-amber-200/60 dark:border-amber-900/40 bg-amber-100/40 dark:bg-amber-950/60"
+					role="dialog"
+					aria-label={t("passengerInfoConfirmPrompt")}
+				>
+					<p class="text-sm text-gray-800 dark:text-gray-100 mb-3">
+						{t("passengerInfoConfirmPrompt")}
+					</p>
+					<div class="flex flex-wrap items-center gap-2">
+						<button
+							type="button"
+							class="btn btn-sm bg-amber-200 hover:bg-amber-300 dark:bg-amber-800 dark:hover:bg-amber-700 border-0 text-amber-900 dark:text-amber-100"
+							onClick={chooseDaily}
+						>
+							{t("passengerInfoConfirmDaily")}
+						</button>
+						<button
+							type="button"
+							class="btn btn-sm btn-ghost text-gray-700 dark:text-gray-200"
+							onClick={chooseNever}
+						>
+							{t("passengerInfoConfirmNever")}
+						</button>
+						<button
+							type="button"
+							class="btn btn-sm btn-ghost text-gray-500 dark:text-gray-400 ml-auto"
+							onClick={() => setPromptOpen(false)}
+						>
+							{t("passengerInfoConfirmCancel")}
+						</button>
+					</div>
+				</div>
+			)}
+			{expanded && !promptOpen && (
 				<div class="px-4 pb-4 pt-1 border-t border-amber-200/60 dark:border-amber-900/40">
-					<PassengerInfoCarousel messages={visibleMessages} />
+					<PassengerInfoCarousel messages={messages} />
 				</div>
 			)}
 		</section>

--- a/src/components/PassengerInfoCarousel.tsx
+++ b/src/components/PassengerInfoCarousel.tsx
@@ -1,0 +1,190 @@
+/** @format */
+
+import { useEffect, useRef, useState } from "preact/hooks";
+import { formatValidityHelsinki } from "../utils/helsinkiTime";
+import type { ActiveMessage } from "../utils/passengerInfo";
+import { t } from "../utils/translations";
+
+interface Props {
+	messages: ActiveMessage[];
+	compact?: boolean;
+	showValidity?: boolean;
+}
+
+const AUTO_ADVANCE_MS = 20000;
+const TRANSITION_MS = 400;
+
+/**
+ * Render one or more active passenger-information messages. When two or more
+ * messages are present the component renders carousel chrome (paging dots,
+ * prev/next buttons) and auto-advances every 20 seconds. Transitions between
+ * messages crossfade. Auto-advance pauses while the carousel is hovered or
+ * focused.
+ */
+export default function PassengerInfoCarousel({
+	messages,
+	compact = false,
+	showValidity = true,
+}: Props) {
+	const [index, setIndex] = useState(0);
+	const [displayedIndex, setDisplayedIndex] = useState(0);
+	const [fading, setFading] = useState(false);
+	const [paused, setPaused] = useState(false);
+	const messageCount = messages.length;
+	const safeIndex = messageCount === 0 ? 0 : index % messageCount;
+
+	useEffect(() => {
+		if (safeIndex !== index) setIndex(safeIndex);
+	}, [safeIndex, index]);
+
+	// Crossfade when the target index changes: fade out, swap, fade in.
+	useEffect(() => {
+		if (messageCount === 0) return;
+		if (displayedIndex === safeIndex) return;
+		setFading(true);
+		const swap = window.setTimeout(() => {
+			setDisplayedIndex(safeIndex);
+			setFading(false);
+		}, TRANSITION_MS);
+		return () => window.clearTimeout(swap);
+	}, [safeIndex, displayedIndex, messageCount]);
+
+	// Keep displayedIndex in range if the message list shrinks.
+	useEffect(() => {
+		if (messageCount === 0) return;
+		if (displayedIndex >= messageCount) {
+			setDisplayedIndex(messageCount - 1);
+		}
+	}, [messageCount, displayedIndex]);
+
+	const intervalRef = useRef<number | null>(null);
+	useEffect(() => {
+		if (intervalRef.current != null) {
+			window.clearInterval(intervalRef.current);
+			intervalRef.current = null;
+		}
+		if (messageCount < 2 || paused) return;
+		intervalRef.current = window.setInterval(() => {
+			setIndex((i) => (i + 1) % messageCount);
+		}, AUTO_ADVANCE_MS);
+		return () => {
+			if (intervalRef.current != null) {
+				window.clearInterval(intervalRef.current);
+				intervalRef.current = null;
+			}
+		};
+	}, [messageCount, paused]);
+
+	if (messageCount === 0) return null;
+
+	const renderedIndex = Math.min(displayedIndex, messageCount - 1);
+	const current = messages[renderedIndex];
+	const single = messageCount === 1;
+
+	const goPrev = () => setIndex((i) => (i - 1 + messageCount) % messageCount);
+	const goNext = () => setIndex((i) => (i + 1) % messageCount);
+
+	const textSize = compact ? "text-sm" : "text-sm sm:text-base";
+	const validity =
+		current.startValidity && current.endValidity
+			? t("passengerInfoValidityRange")
+					.replace("{start}", formatValidityHelsinki(current.startValidity))
+					.replace("{end}", formatValidityHelsinki(current.endValidity))
+			: null;
+
+	return (
+		<section
+			class="relative"
+			aria-roledescription="carousel"
+			aria-label={t("passengerInfoBannerTitle")}
+			onMouseEnter={() => setPaused(true)}
+			onMouseLeave={() => setPaused(false)}
+			onFocusCapture={() => setPaused(true)}
+			onBlurCapture={(event) => {
+				const next = event.relatedTarget as Node | null;
+				if (!next || !event.currentTarget.contains(next)) setPaused(false);
+			}}
+		>
+			<div
+				aria-live="polite"
+				aria-atomic="true"
+				class="transition-opacity ease-in-out"
+				style={{
+					transitionDuration: `${TRANSITION_MS}ms`,
+					opacity: fading ? 0 : 1,
+				}}
+			>
+				<p
+					class={`${textSize} text-gray-800 dark:text-gray-100 leading-snug whitespace-pre-wrap`}
+				>
+					{current.text}
+				</p>
+				{showValidity && validity && (
+					<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+						{t("passengerInfoValidity")}: {validity}
+					</p>
+				)}
+			</div>
+
+			{!single && (
+				<div class="mt-3 flex items-center justify-between gap-2">
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs px-2"
+						aria-label={t("passengerInfoPrev")}
+						onClick={goPrev}
+					>
+						<svg
+							class="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<polyline points="15 18 9 12 15 6" />
+						</svg>
+					</button>
+					<div class="flex items-center gap-1.5" role="tablist">
+						{messages.map((m, i) => (
+							<button
+								key={m.id}
+								type="button"
+								role="tab"
+								aria-selected={i === safeIndex}
+								aria-label={`${t("passengerInfoIndicator")} ${i + 1}/${messageCount}`}
+								class={`h-2 w-2 rounded-full transition-colors ${
+									i === safeIndex
+										? "bg-[#8c4799] dark:bg-[#b388ff]"
+										: "bg-gray-300 dark:bg-gray-600"
+								}`}
+								onClick={() => setIndex(i)}
+							/>
+						))}
+					</div>
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs px-2"
+						aria-label={t("passengerInfoNext")}
+						onClick={goNext}
+					>
+						<svg
+							class="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<polyline points="9 18 15 12 9 6" />
+						</svg>
+					</button>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/src/components/PassengerInfoCarousel.tsx
+++ b/src/components/PassengerInfoCarousel.tsx
@@ -147,13 +147,12 @@ export default function PassengerInfoCarousel({
 							<polyline points="15 18 9 12 15 6" />
 						</svg>
 					</button>
-					<div class="flex items-center gap-1.5" role="tablist">
+					<div class="flex items-center gap-1.5">
 						{messages.map((m, i) => (
 							<button
 								key={m.id}
 								type="button"
-								role="tab"
-								aria-selected={i === safeIndex}
+								aria-current={i === safeIndex ? "true" : undefined}
 								aria-label={`${t("passengerInfoIndicator")} ${i + 1}/${messageCount}`}
 								class={`h-2 w-2 rounded-full transition-colors ${
 									i === safeIndex

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -18,10 +18,12 @@ import { showToast } from "@/utils/toast";
 import type { Train } from "../types";
 import { getRelevantTrackInfo } from "../utils/api";
 import { hapticImpact } from "../utils/haptics";
+import type { ActiveMessage } from "../utils/passengerInfo";
 import { calculateDuration, getDepartureDate } from "../utils/trainUtils";
 import { t } from "../utils/translations";
 import { getDebugMode, subscribeToDebugMode } from "./DebugToggle";
 import TimeDisplay from "./TimeDisplay";
+import TrainMessagePanel from "./TrainMessagePanel";
 
 // Fixed reference point for animation sync - captured once at module load
 const ANIMATION_SYNC_BASELINE = Date.now();
@@ -40,6 +42,7 @@ interface Props {
 	getDurationSpeedType?: (
 		durationMinutes: number,
 	) => "fast" | "slow" | "normal";
+	messages?: ActiveMessage[];
 }
 
 // Swipe gesture constants
@@ -120,6 +123,7 @@ export default function TrainCard({
 	onDepart,
 	onReappear,
 	getDurationSpeedType,
+	messages,
 }: Props) {
 	const [, setLanguageChange] = useState(0);
 	const [isHighlighted, setIsHighlighted] = useState(false);
@@ -136,6 +140,23 @@ export default function TrainCard({
 	// Swipe gesture state
 	const [swipeOffset, setSwipeOffset] = useState(0);
 	const [isTransitioning, setIsTransitioning] = useState(false);
+	const [messagesOpen, setMessagesOpen] = useState(false);
+	const messagesPanelId = `train-${train.trainNumber}-messages`;
+	const hasMessages = (messages?.length ?? 0) > 0;
+
+	useEffect(() => {
+		if (!messagesOpen) return;
+		const handleKey = (event: KeyboardEvent) => {
+			if (event.key === "Escape") setMessagesOpen(false);
+		};
+		window.addEventListener("keydown", handleKey);
+		return () => window.removeEventListener("keydown", handleKey);
+	}, [messagesOpen]);
+
+	// Auto-close panel if messages disappear (e.g. delivery window ended).
+	useEffect(() => {
+		if (!hasMessages && messagesOpen) setMessagesOpen(false);
+	}, [hasMessages, messagesOpen]);
 	const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 	const isSwipingRef = useRef(false);
 	const hasTriggeredRef = useRef(false);
@@ -856,7 +877,38 @@ export default function TrainCard({
 							departureRow?.unknownDelay ? "true" : "false"
 						}
 					>
-						<div class="card-body p-3 sm:p-4">
+						<div class="card-body p-3 sm:p-4 relative">
+							{hasMessages && (
+								<button
+									type="button"
+									class="absolute top-1.5 right-1.5 z-10 inline-flex items-center justify-center h-7 w-7 rounded-full bg-amber-100 dark:bg-amber-900/70 text-amber-700 dark:text-amber-200 hover:bg-amber-200 dark:hover:bg-amber-800 transition-colors shadow-sm"
+									aria-label={t("passengerInfoTrainButton")}
+									aria-expanded={messagesOpen}
+									aria-controls={messagesPanelId}
+									onClick={(event) => {
+										event.stopPropagation();
+										setMessagesOpen((v) => !v);
+									}}
+								>
+									<svg
+										class="w-4 h-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										aria-hidden="true"
+									>
+										<circle cx="12" cy="12" r="10" />
+										<line x1="12" y1="8" x2="12" y2="12" />
+										<line x1="12" y1="16" x2="12.01" y2="16" />
+									</svg>
+									{messages && messages.length > 1 && (
+										<span class="sr-only">{messages.length}</span>
+									)}
+								</button>
+							)}
 							<div class="flex items-start justify-between gap-2 sm:gap-4 min-h-[76px] sm:min-h-20">
 								<div class="flex items-center gap-3 sm:gap-4 flex-1 min-w-0 overflow-hidden">
 									{/* Train identifier */}
@@ -1096,6 +1148,12 @@ export default function TrainCard({
 										? t("departingSoon")
 										: ""}
 							</div>
+							{messagesOpen && messages && messages.length > 0 && (
+								<TrainMessagePanel
+									messages={messages}
+									panelId={messagesPanelId}
+								/>
+							)}
 						</div>
 					</div>
 				</div>

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -882,7 +882,11 @@ export default function TrainCard({
 								<button
 									type="button"
 									class="absolute top-1.5 right-1.5 z-10 inline-flex items-center justify-center h-7 w-7 rounded-full bg-amber-100 dark:bg-amber-900/70 text-amber-700 dark:text-amber-200 hover:bg-amber-200 dark:hover:bg-amber-800 transition-colors shadow-sm"
-									aria-label={t("passengerInfoTrainButton")}
+									aria-label={
+										messages && messages.length > 1
+											? `${t("passengerInfoTrainButton")} (${messages.length})`
+											: t("passengerInfoTrainButton")
+									}
 									aria-expanded={messagesOpen}
 									aria-controls={messagesPanelId}
 									onClick={(event) => {
@@ -904,9 +908,6 @@ export default function TrainCard({
 										<line x1="12" y1="8" x2="12" y2="12" />
 										<line x1="12" y1="16" x2="12.01" y2="16" />
 									</svg>
-									{messages && messages.length > 1 && (
-										<span class="sr-only">{messages.length}</span>
-									)}
 								</button>
 							)}
 							<div class="flex items-start justify-between gap-2 sm:gap-4 min-h-[76px] sm:min-h-20">

--- a/src/components/TrainCard.tsx
+++ b/src/components/TrainCard.tsx
@@ -141,7 +141,7 @@ export default function TrainCard({
 	const [swipeOffset, setSwipeOffset] = useState(0);
 	const [isTransitioning, setIsTransitioning] = useState(false);
 	const [messagesOpen, setMessagesOpen] = useState(false);
-	const messagesPanelId = `train-${train.trainNumber}-messages`;
+	const messagesPanelId = `train-${train.trainNumber}-${stationCode}-${destinationCode}-messages`;
 	const hasMessages = (messages?.length ?? 0) > 0;
 
 	useEffect(() => {

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -746,6 +746,7 @@ export default function TrainList({
 		if (!stationCode || !destinationCode) return;
 		if (!isPageVisible) return;
 		let cancelled = false;
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
 		const dates = uniqueDatesKey ? uniqueDatesKey.split(",") : [];
 
 		async function loadMessages() {
@@ -774,11 +775,19 @@ export default function TrainList({
 			}
 		}
 
-		void loadMessages();
-		const intervalId = window.setInterval(loadMessages, 60_000);
+		// setTimeout loop (not setInterval) so slow fetches can't overlap and
+		// resolve out of order under tab throttling or network congestion.
+		const tick = async () => {
+			await loadMessages();
+			if (!cancelled) {
+				timeoutId = setTimeout(tick, 60_000);
+			}
+		};
+		void tick();
+
 		return () => {
 			cancelled = true;
-			window.clearInterval(intervalId);
+			if (timeoutId) clearTimeout(timeoutId);
 		};
 	}, [stationCode, destinationCode, uniqueDatesKey, isPageVisible]);
 

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -13,13 +13,26 @@ import { getFavoritesSync, initStorage } from "@/utils/storage";
 import { showToast } from "@/utils/toast";
 import { useLanguageChange } from "../hooks/useLanguageChange";
 import type { Station, Train } from "../types";
-import { fetchTrains, type ServiceStatusInfo } from "../utils/api";
+import {
+	fetchActivePassengerMessages,
+	fetchTrains,
+	type ServiceStatusInfo,
+} from "../utils/api";
 import { hapticLight } from "../utils/haptics";
+import { helsinkiParts } from "../utils/helsinkiTime";
+import { getCurrentLanguage } from "../utils/language";
+import {
+	type ActiveMessage,
+	type PassengerInformationMessage,
+	partitionActiveMessages,
+	trainMessageKey,
+} from "../utils/passengerInfo";
 import { getLocalizedStationName } from "../utils/stationNames";
 import { getDepartureDate } from "../utils/trainUtils";
 import { t } from "../utils/translations";
 import ErrorState from "./ErrorState";
 import LinearProgress from "./LinearProgress";
+import PassengerInfoBanner from "./PassengerInfoBanner";
 import ProgressCircle from "./ProgressCircle";
 import TrainCard from "./TrainCard";
 import TrainListSkeleton from "./TrainListSkeleton";
@@ -120,7 +133,7 @@ export default function TrainList({
 	destinationCode,
 	stations,
 }: Props) {
-	useLanguageChange();
+	const languageVersion = useLanguageChange();
 	const [state, setState] = useState({
 		trains: [] as Train[],
 		loading: true,
@@ -696,6 +709,84 @@ export default function TrainList({
 
 	const displayedTrains = sortedTrains.slice(0, displayedTrainCount);
 	const hasMoreTrains = sortedTrains.length > displayedTrainCount;
+
+	// --- Passenger information messages ----------------------------------------
+	const [rawPassengerMessages, setRawPassengerMessages] = useState<
+		PassengerInformationMessage[]
+	>([]);
+
+	// Set of `${trainNumber}_${originDate}` keys for currently-displayed trains.
+	// Uses each train's first-origin departure row (timeTableRows[0]), which is
+	// the date the passenger-information API keys train-specific messages by;
+	// for midnight-crossing services this is the previous calendar day.
+	const { displayedTrainKeys, uniqueDepartureDates } = useMemo(() => {
+		const keys = new Set<string>();
+		const dates = new Set<string>();
+		for (const train of displayedTrains) {
+			const originRow = train.timeTableRows[0];
+			if (!originRow?.scheduledTime) continue;
+			const helsinki = helsinkiParts(new Date(originRow.scheduledTime));
+			dates.add(helsinki.date);
+			keys.add(trainMessageKey(train.trainNumber, helsinki.date));
+		}
+		return {
+			displayedTrainKeys: keys,
+			uniqueDepartureDates: Array.from(dates).sort(),
+		};
+	}, [displayedTrains]);
+
+	const uniqueDatesKey = uniqueDepartureDates.join(",");
+
+	useEffect(() => {
+		if (!stationCode || !destinationCode) return;
+		let cancelled = false;
+		const dates = uniqueDatesKey ? uniqueDatesKey.split(",") : [];
+
+		async function loadMessages() {
+			try {
+				const [general, perTrain] = await Promise.all([
+					fetchActivePassengerMessages({
+						stationCodes: [stationCode, destinationCode],
+						generalOnly: true,
+					}),
+					dates.length > 0
+						? fetchActivePassengerMessages({
+								stationCodes: [stationCode, destinationCode],
+								departureDates: dates,
+							})
+						: Promise.resolve([] as PassengerInformationMessage[]),
+				]);
+				if (cancelled) return;
+				const merged = new Map<string, PassengerInformationMessage>();
+				for (const m of general) merged.set(m.id, m);
+				for (const m of perTrain) if (!merged.has(m.id)) merged.set(m.id, m);
+				setRawPassengerMessages(Array.from(merged.values()));
+			} catch (error) {
+				if (!cancelled) {
+					console.error("[TrainList] Passenger info load failed:", error);
+				}
+			}
+		}
+
+		void loadMessages();
+		const intervalId = window.setInterval(loadMessages, 60_000);
+		return () => {
+			cancelled = true;
+			window.clearInterval(intervalId);
+		};
+	}, [stationCode, destinationCode, uniqueDatesKey]);
+
+	const { generalMessages, perTrainMessages } = useMemo(() => {
+		const lang = getCurrentLanguage();
+		const { general, perTrain } = partitionActiveMessages(
+			rawPassengerMessages,
+			currentTime,
+			lang,
+			displayedTrainKeys,
+		);
+		return { generalMessages: general, perTrainMessages: perTrain };
+	}, [rawPassengerMessages, currentTime, languageVersion, displayedTrainKeys]);
+
 	const refreshProgress = useMemo(() => {
 		const interval = Math.max(currentRefreshInterval, 1);
 		const elapsed = currentTime.getTime() - lastRefreshAt;
@@ -804,11 +895,24 @@ export default function TrainList({
 						</label>
 					)}
 				</div>
+				{generalMessages.length > 0 && (
+					<PassengerInfoBanner messages={generalMessages} />
+				)}
 				<div ref={listContainerRef} class="flex flex-col gap-4">
 					{displayedTrains.map((train, index) => {
 						const journeyKey = `${train.trainNumber}-${stationCode}-${destinationCode}`;
 						const isSlow = isTrainSlow(train);
 						const isHiddenByFilter = hideSlowTrains && isSlow;
+						const originRow = train.timeTableRows[0];
+						let trainMessages: ActiveMessage[] | undefined;
+						if (originRow?.scheduledTime) {
+							const originDate = helsinkiParts(
+								new Date(originRow.scheduledTime),
+							).date;
+							trainMessages = perTrainMessages.get(
+								trainMessageKey(train.trainNumber, originDate),
+							);
+						}
 						return (
 							<div
 								key={journeyKey}
@@ -835,6 +939,7 @@ export default function TrainList({
 									onDepart={() => handleTrainDeparted(journeyKey)}
 									onReappear={() => handleTrainReappear(journeyKey)}
 									getDurationSpeedType={getDurationSpeedType}
+									messages={trainMessages}
 								/>
 							</div>
 						);

--- a/src/components/TrainList.tsx
+++ b/src/components/TrainList.tsx
@@ -707,7 +707,10 @@ export default function TrainList({
 		});
 	}, [filteredTrains, stationCode, favoritesVersion]);
 
-	const displayedTrains = sortedTrains.slice(0, displayedTrainCount);
+	const displayedTrains = useMemo(
+		() => sortedTrains.slice(0, displayedTrainCount),
+		[sortedTrains, displayedTrainCount],
+	);
 	const hasMoreTrains = sortedTrains.length > displayedTrainCount;
 
 	// --- Passenger information messages ----------------------------------------
@@ -716,16 +719,18 @@ export default function TrainList({
 	>([]);
 
 	// Set of `${trainNumber}_${originDate}` keys for currently-displayed trains.
-	// Uses each train's first-origin departure row (timeTableRows[0]), which is
-	// the date the passenger-information API keys train-specific messages by;
-	// for midnight-crossing services this is the previous calendar day.
+	// Uses the train's true first-origin departure time captured in api.ts
+	// before timeTableRows is sliced to the selected station; this is the date
+	// the passenger-information API keys train-specific messages by, and
+	// matches the train's "service date" even for midnight-crossing services.
 	const { displayedTrainKeys, uniqueDepartureDates } = useMemo(() => {
 		const keys = new Set<string>();
 		const dates = new Set<string>();
 		for (const train of displayedTrains) {
-			const originRow = train.timeTableRows[0];
-			if (!originRow?.scheduledTime) continue;
-			const helsinki = helsinkiParts(new Date(originRow.scheduledTime));
+			const originTime =
+				train.originDepartureTime ?? train.timeTableRows[0]?.scheduledTime;
+			if (!originTime) continue;
+			const helsinki = helsinkiParts(new Date(originTime));
 			dates.add(helsinki.date);
 			keys.add(trainMessageKey(train.trainNumber, helsinki.date));
 		}
@@ -739,6 +744,7 @@ export default function TrainList({
 
 	useEffect(() => {
 		if (!stationCode || !destinationCode) return;
+		if (!isPageVisible) return;
 		let cancelled = false;
 		const dates = uniqueDatesKey ? uniqueDatesKey.split(",") : [];
 
@@ -774,7 +780,7 @@ export default function TrainList({
 			cancelled = true;
 			window.clearInterval(intervalId);
 		};
-	}, [stationCode, destinationCode, uniqueDatesKey]);
+	}, [stationCode, destinationCode, uniqueDatesKey, isPageVisible]);
 
 	const { generalMessages, perTrainMessages } = useMemo(() => {
 		const lang = getCurrentLanguage();
@@ -903,12 +909,12 @@ export default function TrainList({
 						const journeyKey = `${train.trainNumber}-${stationCode}-${destinationCode}`;
 						const isSlow = isTrainSlow(train);
 						const isHiddenByFilter = hideSlowTrains && isSlow;
-						const originRow = train.timeTableRows[0];
+						const originTime =
+							train.originDepartureTime ??
+							train.timeTableRows[0]?.scheduledTime;
 						let trainMessages: ActiveMessage[] | undefined;
-						if (originRow?.scheduledTime) {
-							const originDate = helsinkiParts(
-								new Date(originRow.scheduledTime),
-							).date;
+						if (originTime) {
+							const originDate = helsinkiParts(new Date(originTime)).date;
 							trainMessages = perTrainMessages.get(
 								trainMessageKey(train.trainNumber, originDate),
 							);

--- a/src/components/TrainMessagePanel.tsx
+++ b/src/components/TrainMessagePanel.tsx
@@ -1,0 +1,30 @@
+/** @format */
+
+import type { ActiveMessage } from "../utils/passengerInfo";
+import { t } from "../utils/translations";
+import PassengerInfoCarousel from "./PassengerInfoCarousel";
+
+interface Props {
+	messages: ActiveMessage[];
+	panelId: string;
+}
+
+/**
+ * Inline panel rendered beneath the TrainCard row when the train's message
+ * icon-button is open. Inline (not popover) because TrainCard's outer
+ * container uses `overflow-hidden` for swipe-gesture overlays, which would
+ * clip a floating popover. Reuses PassengerInfoCarousel for the rare case of
+ * multiple active messages on the same train.
+ */
+export default function TrainMessagePanel({ messages, panelId }: Props) {
+	if (messages.length === 0) return null;
+	return (
+		<section
+			id={panelId}
+			class="mt-3 rounded-lg border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/60 p-3"
+			aria-label={t("passengerInfoBannerTitle")}
+		>
+			<PassengerInfoCarousel messages={messages} compact showValidity />
+		</section>
+	);
+}

--- a/src/components/__tests__/__snapshots__/TrainCard.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TrainCard.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`TrainCard > snapshots > matches snapshot for cancelled train 1`] = `
       data-train-unknown-delay="false"
     >
       <div
-        class="card-body p-3 sm:p-4"
+        class="card-body p-3 sm:p-4 relative"
       >
         <div
           class="flex items-start justify-between gap-2 sm:gap-4 min-h-[76px] sm:min-h-20"
@@ -224,7 +224,7 @@ exports[`TrainCard > snapshots > matches snapshot for highlighted train 1`] = `
       data-train-unknown-delay="false"
     >
       <div
-        class="card-body p-3 sm:p-4"
+        class="card-body p-3 sm:p-4 relative"
       >
         <div
           class="flex items-start justify-between gap-2 sm:gap-4 min-h-[76px] sm:min-h-20"
@@ -463,7 +463,7 @@ exports[`TrainCard > snapshots > matches snapshot for normal train 1`] = `
       data-train-unknown-delay="false"
     >
       <div
-        class="card-body p-3 sm:p-4"
+        class="card-body p-3 sm:p-4 relative"
       >
         <div
           class="flex items-start justify-between gap-2 sm:gap-4 min-h-[76px] sm:min-h-20"

--- a/src/config/featureAnnouncement.ts
+++ b/src/config/featureAnnouncement.ts
@@ -42,8 +42,7 @@ export const featureAnnouncementConfig = {
 	 * - translationKey: key from translations.ts for the feature description
 	 */
 	features: [
-		{ icon: "♿", translationKey: "newFeaturesAccessibility" },
-		{ icon: "📱", translationKey: "newFeaturesCleanerMobile" },
+		{ icon: "📣", translationKey: "newFeaturesPassengerInfo" },
 		{ icon: "🛠️", translationKey: "newFeaturesPolish" },
 	] as Array<{ icon: string; translationKey: string }>,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface Train {
 	isDeparted?: boolean;
 	/** ISO string when train is considered departed (actual or inferred) */
 	departedAt?: string;
+	/** ISO scheduled time of the train's true first origin, captured before timeTableRows is sliced to the selected station. */
+	originDepartureTime?: string;
 }
 
 export interface TimeTableRow {

--- a/src/utils/__tests__/passengerInfo.test.ts
+++ b/src/utils/__tests__/passengerInfo.test.ts
@@ -1,0 +1,431 @@
+/** @format */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	__resetPassengerInfoCacheForTests,
+	fetchActivePassengerMessages,
+} from "@/utils/api";
+import {
+	isWithinRules,
+	type PassengerInformationMessage,
+	partitionActiveMessages,
+	pickDisplay,
+	trainMessageKey,
+	type VideoDeliveryRules,
+} from "@/utils/passengerInfo";
+
+function makeMessage(
+	overrides: Partial<PassengerInformationMessage> & { id: string },
+): PassengerInformationMessage {
+	return {
+		startValidity: "2026-01-01T00:00:00Z",
+		endValidity: "2027-01-01T00:00:00Z",
+		trainNumber: null,
+		trainDepartureDate: null,
+		stations: [],
+		...overrides,
+	};
+}
+
+describe("pickDisplay (video-only)", () => {
+	it("returns video text in the requested language", () => {
+		const msg = makeMessage({
+			id: "1",
+			video: { text: { fi: "FI", sv: "SV", en: "EN" } },
+		});
+		expect(pickDisplay(msg, "fi")).toEqual({ text: "FI", rules: undefined });
+	});
+
+	it("falls back en → fi → sv when the requested language is null", () => {
+		const enOnly = makeMessage({
+			id: "1",
+			video: { text: { fi: null, sv: null, en: "EN" } },
+		});
+		expect(pickDisplay(enOnly, "fi")?.text).toBe("EN");
+
+		const fiOnly = makeMessage({
+			id: "2",
+			video: { text: { fi: "FI", sv: null, en: null } },
+		});
+		expect(pickDisplay(fiOnly, "sv")?.text).toBe("FI");
+
+		const svOnly = makeMessage({
+			id: "3",
+			video: { text: { fi: null, sv: "SV", en: null } },
+		});
+		expect(pickDisplay(svOnly, "en")?.text).toBe("SV");
+	});
+
+	it("returns null when video is missing", () => {
+		expect(pickDisplay(makeMessage({ id: "1" }), "fi")).toBeNull();
+	});
+
+	it("returns null when no language has video text (no audio fallback)", () => {
+		const msg = makeMessage({
+			id: "1",
+			video: { text: { fi: null, sv: null, en: null } },
+		});
+		expect(pickDisplay(msg, "fi")).toBeNull();
+	});
+});
+
+describe("isWithinRules — CONTINUOS_VISUALIZATION", () => {
+	const baseRules: VideoDeliveryRules = {
+		deliveryType: "CONTINUOS_VISUALIZATION",
+		startDateTime: "2026-06-01T00:00:00Z",
+		endDateTime: "2026-06-08T00:00:00Z",
+		startTime: "14:10",
+		endTime: "04:30",
+		weekDays: [
+			"MONDAY",
+			"TUESDAY",
+			"WEDNESDAY",
+			"THURSDAY",
+			"FRIDAY",
+			"SATURDAY",
+			"SUNDAY",
+		],
+	};
+
+	it("is active mid-window", () => {
+		expect(isWithinRules(baseRules, new Date("2026-06-04T12:00:00Z"))).toBe(
+			true,
+		);
+	});
+
+	it("is inactive before the start time on the first day", () => {
+		// startDateTime 2026-06-01T00:00Z = 2026-06-01 03:00 Helsinki (DST).
+		// startTime 14:10 Helsinki => effective start is 2026-06-01 14:10 Helsinki
+		// = 11:10Z. So 10:00Z on 2026-06-01 is BEFORE the effective start.
+		expect(isWithinRules(baseRules, new Date("2026-06-01T10:00:00Z"))).toBe(
+			false,
+		);
+	});
+
+	it("is inactive entirely before the outer window", () => {
+		expect(isWithinRules(baseRules, new Date("2026-05-30T12:00:00Z"))).toBe(
+			false,
+		);
+	});
+
+	it("is inactive after the end-time on the last day", () => {
+		// endDateTime 2026-06-08T00:00Z = 2026-06-08 03:00 Helsinki.
+		// endTime 04:30 Helsinki => effective end is 2026-06-08 04:30 Helsinki
+		// = 01:30Z. 01:30Z on 2026-06-08 is the boundary; 01:31Z is past it.
+		expect(isWithinRules(baseRules, new Date("2026-06-08T01:31:00Z"))).toBe(
+			false,
+		);
+	});
+
+	it("honours weekDays gating", () => {
+		const noSaturday: VideoDeliveryRules = {
+			...baseRules,
+			weekDays: [
+				"MONDAY",
+				"TUESDAY",
+				"WEDNESDAY",
+				"THURSDAY",
+				"FRIDAY",
+				"SUNDAY",
+			],
+		};
+		// Saturday 2026-06-06 12:00Z → 15:00 Helsinki, inside outer window
+		expect(isWithinRules(noSaturday, new Date("2026-06-06T12:00:00Z"))).toBe(
+			false,
+		);
+		// Sunday 2026-06-07 12:00Z → active
+		expect(isWithinRules(noSaturday, new Date("2026-06-07T12:00:00Z"))).toBe(
+			true,
+		);
+	});
+
+	it("falls back to startDateTime/endDateTime when start/endTime are missing", () => {
+		const rules: VideoDeliveryRules = {
+			...baseRules,
+			startTime: undefined,
+			endTime: undefined,
+		};
+		expect(isWithinRules(rules, new Date("2026-06-01T00:00:01Z"))).toBe(true);
+		expect(isWithinRules(rules, new Date("2026-05-31T23:59:59Z"))).toBe(false);
+	});
+
+	it("treats no rules as 'always active'", () => {
+		expect(isWithinRules(undefined, new Date())).toBe(true);
+	});
+});
+
+describe("isWithinRules — WHEN", () => {
+	const weekdayWindow: VideoDeliveryRules = {
+		deliveryType: "WHEN",
+		startDateTime: "2026-01-01T00:00:00Z",
+		endDateTime: "2030-01-01T00:00:00Z",
+		startTime: "08:25",
+		endTime: "21:00",
+		weekDays: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+	};
+
+	it("is active on a weekday inside the daily window", () => {
+		// Wed 2026-06-03 12:00 Helsinki = 09:00Z (DST)
+		expect(isWithinRules(weekdayWindow, new Date("2026-06-03T09:00:00Z"))).toBe(
+			true,
+		);
+	});
+
+	it("is inactive on a weekday outside the daily window", () => {
+		// Wed 2026-06-03 22:00 Helsinki = 19:00Z
+		expect(isWithinRules(weekdayWindow, new Date("2026-06-03T19:00:00Z"))).toBe(
+			false,
+		);
+	});
+
+	it("is inactive on a weekend even within the daily window", () => {
+		// Sun 2026-06-07 12:00 Helsinki = 09:00Z
+		expect(isWithinRules(weekdayWindow, new Date("2026-06-07T09:00:00Z"))).toBe(
+			false,
+		);
+	});
+
+	const overnightWindow: VideoDeliveryRules = {
+		deliveryType: "WHEN",
+		startDateTime: "2026-01-01T00:00:00Z",
+		endDateTime: "2030-01-01T00:00:00Z",
+		startTime: "22:00",
+		endTime: "06:00",
+		weekDays: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+	};
+
+	it("handles overnight wrap (before midnight)", () => {
+		// Wed 2026-06-03 23:30 Helsinki = 20:30Z
+		expect(
+			isWithinRules(overnightWindow, new Date("2026-06-03T20:30:00Z")),
+		).toBe(true);
+	});
+
+	it("handles overnight wrap (after midnight)", () => {
+		// Thu 2026-06-04 02:00 Helsinki = Wed 2026-06-03 23:00Z
+		expect(
+			isWithinRules(overnightWindow, new Date("2026-06-03T23:00:00Z")),
+		).toBe(true);
+	});
+
+	it("is inactive mid-day during an overnight window", () => {
+		// Wed 2026-06-03 12:00 Helsinki = 09:00Z
+		expect(
+			isWithinRules(overnightWindow, new Date("2026-06-03T09:00:00Z")),
+		).toBe(false);
+	});
+});
+
+describe("partitionActiveMessages", () => {
+	const now = new Date("2026-06-03T09:00:00Z"); // Wed 12:00 Helsinki
+
+	const general = makeMessage({
+		id: "g1",
+		trainNumber: null,
+		video: { text: { fi: "Yleinen tiedote", sv: null, en: null } },
+	});
+	const matchingTrain = makeMessage({
+		id: "t1",
+		trainNumber: 1234,
+		trainDepartureDate: "2026-06-03",
+		video: { text: { fi: "Junatiedote", sv: null, en: null } },
+	});
+	const secondForSameTrain = makeMessage({
+		id: "t2",
+		trainNumber: 1234,
+		trainDepartureDate: "2026-06-03",
+		video: { text: { fi: "Toinen", sv: null, en: null } },
+	});
+	const unmatchedTrain = makeMessage({
+		id: "t3",
+		trainNumber: 9999,
+		trainDepartureDate: "2026-06-03",
+		video: { text: { fi: "Ei sovi", sv: null, en: null } },
+	});
+
+	const displayedKeys = new Set([trainMessageKey(1234, "2026-06-03")]);
+
+	it("routes trainNumber=null messages to the general pool only", () => {
+		const { general: g, perTrain } = partitionActiveMessages(
+			[general],
+			now,
+			"fi",
+			displayedKeys,
+		);
+		expect(g).toHaveLength(1);
+		expect(g[0].id).toBe("g1");
+		expect(perTrain.size).toBe(0);
+	});
+
+	it("drops per-train messages that do not match a displayed train", () => {
+		const { general: g, perTrain } = partitionActiveMessages(
+			[unmatchedTrain],
+			now,
+			"fi",
+			displayedKeys,
+		);
+		expect(g).toHaveLength(0);
+		expect(perTrain.size).toBe(0);
+	});
+
+	it("collects multiple active messages for the same train", () => {
+		const { perTrain } = partitionActiveMessages(
+			[matchingTrain, secondForSameTrain],
+			now,
+			"fi",
+			displayedKeys,
+		);
+		const arr = perTrain.get(trainMessageKey(1234, "2026-06-03"));
+		expect(arr).toHaveLength(2);
+	});
+
+	it("dedupes by id within a single partition call", () => {
+		const dup: PassengerInformationMessage = { ...matchingTrain };
+		const { perTrain } = partitionActiveMessages(
+			[matchingTrain, dup],
+			now,
+			"fi",
+			displayedKeys,
+		);
+		const arr = perTrain.get(trainMessageKey(1234, "2026-06-03"));
+		expect(arr).toHaveLength(1);
+	});
+
+	it("drops messages without displayable video text", () => {
+		const noText = makeMessage({
+			id: "blank",
+			trainNumber: null,
+			video: { text: { fi: null, sv: null, en: null } },
+		});
+		const { general: g } = partitionActiveMessages(
+			[noText],
+			now,
+			"fi",
+			displayedKeys,
+		);
+		expect(g).toHaveLength(0);
+	});
+});
+
+describe("fetchActivePassengerMessages URL construction", () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	let urls: string[];
+
+	beforeEach(() => {
+		__resetPassengerInfoCacheForTests();
+		urls = [];
+		fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input: RequestInfo | URL) => {
+				const url = typeof input === "string" ? input : input.toString();
+				urls.push(url);
+				return new Response("[]", {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it("issues one general request per station (the API only honours the last station= param)", async () => {
+		await fetchActivePassengerMessages({
+			stationCodes: ["HKI", "PSL"],
+			generalOnly: true,
+		});
+		expect(urls).toHaveLength(2);
+		const stations = urls
+			.map((u) => new URL(u).searchParams.get("station"))
+			.sort();
+		expect(stations).toEqual(["HKI", "PSL"]);
+		for (const raw of urls) {
+			const url = new URL(raw);
+			expect(url.pathname.endsWith("/v1/passenger-information/active")).toBe(
+				true,
+			);
+			expect(url.searchParams.getAll("station")).toHaveLength(1);
+			expect(url.searchParams.get("only_general")).toBe("true");
+			expect(url.searchParams.has("train_departure_date")).toBe(false);
+		}
+	});
+
+	it("issues one per-train request per (station, unique date) pair", async () => {
+		await fetchActivePassengerMessages({
+			stationCodes: ["HKI", "PSL"],
+			departureDates: ["2026-05-28", "2026-05-28", "2026-05-27"],
+		});
+		expect(urls).toHaveLength(4);
+		const pairs = urls
+			.map((raw) => {
+				const url = new URL(raw);
+				return `${url.searchParams.get("station")}|${url.searchParams.get("train_departure_date")}`;
+			})
+			.sort();
+		expect(pairs).toEqual([
+			"HKI|2026-05-27",
+			"HKI|2026-05-28",
+			"PSL|2026-05-27",
+			"PSL|2026-05-28",
+		]);
+		for (const raw of urls) {
+			const url = new URL(raw);
+			expect(url.searchParams.getAll("station")).toHaveLength(1);
+			expect(url.searchParams.has("only_general")).toBe(false);
+		}
+	});
+
+	it("merges results across stations and dates, deduping by id", async () => {
+		const sharedMessage = JSON.stringify([
+			{
+				id: "shared",
+				startValidity: "2026-01-01T00:00:00Z",
+				endValidity: "2027-01-01T00:00:00Z",
+				trainNumber: 1,
+				trainDepartureDate: "2026-05-28",
+				stations: [],
+				video: { text: { fi: "x", sv: null, en: null } },
+			},
+		]);
+		fetchSpy.mockReset();
+		fetchSpy.mockImplementation(
+			async () =>
+				new Response(sharedMessage, {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+		);
+		__resetPassengerInfoCacheForTests();
+		const merged = await fetchActivePassengerMessages({
+			stationCodes: ["HKI", "PSL"],
+			departureDates: ["2026-05-27", "2026-05-28"],
+		});
+		expect(merged.map((m) => m.id)).toEqual(["shared"]);
+	});
+
+	it("treats station pair as order-independent (HKI,LH and LH,HKI yield the same URL set)", async () => {
+		await fetchActivePassengerMessages({
+			stationCodes: ["HKI", "LH"],
+			generalOnly: true,
+		});
+		const firstSet = new Set(urls);
+		urls.length = 0;
+		__resetPassengerInfoCacheForTests();
+		await fetchActivePassengerMessages({
+			stationCodes: ["LH", "HKI"],
+			generalOnly: true,
+		});
+		const secondSet = new Set(urls);
+		expect(secondSet).toEqual(firstSet);
+	});
+
+	it("returns [] when stationCodes is empty", async () => {
+		const result = await fetchActivePassengerMessages({
+			stationCodes: [],
+			generalOnly: true,
+		});
+		expect(result).toEqual([]);
+		expect(urls).toHaveLength(0);
+	});
+});

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,6 @@
 /** biome-ignore-all lint/security/noGlobalEval: we're intentionally using it to avoid bundling issues */
 import type { Station, Train } from "../types";
+import type { PassengerInformationMessage } from "./passengerInfo";
 import { getDepartureDate } from "./trainUtils";
 
 /**
@@ -32,6 +33,7 @@ const ENDPOINTS = {
 	GRAPHQL: `${BASE_URL}/v2/graphql/graphql`,
 	STATIONS: `${BASE_URL}/v1/metadata/stations`,
 	LIVE_TRAINS: `${BASE_URL}/v1/live-trains/station`,
+	PASSENGER_INFO: `${BASE_URL}/v1/passenger-information/active`,
 	STATUS: "https://status.digitraffic.fi/index.json",
 } as const;
 
@@ -48,6 +50,7 @@ const CACHE_CONFIG = {
 	TRAIN_DURATION: 2 * 60 * 1000, // 2 minutes (shorter for real-time updates)
 	TRAIN_DURATION_URGENT: 30 * 1000, // 30 seconds for imminent trains
 	DESTINATION_DURATION: 5 * 60 * 1000, // 5 minutes for destination cache
+	PASSENGER_INFO_DURATION: 60 * 1000, // 60 seconds for passenger information
 	MAX_SIZE: 100, // Maximum number of entries in the cache
 } as const;
 
@@ -1078,6 +1081,123 @@ function sortByDepartureTime(a: Train, b: Train, stationCode: string): number {
  */
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Passenger information messages
+// ---------------------------------------------------------------------------
+
+const passengerInfoCache = new Map<
+	string,
+	CacheEntry<PassengerInformationMessage[]>
+>();
+
+function buildPassengerInfoUrl(params: {
+	station: string;
+	departureDate?: string;
+	generalOnly?: boolean;
+}): string {
+	const search = new URLSearchParams();
+	search.append("station", params.station);
+	if (params.generalOnly) {
+		search.append("only_general", "true");
+	}
+	if (params.departureDate) {
+		search.append("train_departure_date", params.departureDate);
+	}
+	return `${ENDPOINTS.PASSENGER_INFO}?${search.toString()}`;
+}
+
+async function requestPassengerInfo(
+	url: string,
+): Promise<PassengerInformationMessage[]> {
+	const cached = passengerInfoCache.get(url);
+	if (
+		cached &&
+		Date.now() - cached.timestamp < CACHE_CONFIG.PASSENGER_INFO_DURATION
+	) {
+		return cached.data;
+	}
+
+	const data = await makeRateLimitedRequest(url, async () => {
+		const response = await makeRequestWithBackoff(() =>
+			fetch(url, { headers: DEFAULT_HEADERS }),
+		);
+		if (!response.ok) {
+			throw new Error(`Passenger info request failed: ${response.status}`);
+		}
+		const json = (await response.json()) as PassengerInformationMessage[];
+		return Array.isArray(json) ? json : [];
+	});
+
+	passengerInfoCache.set(url, { data, timestamp: Date.now() });
+	cleanupCache(passengerInfoCache);
+	return data;
+}
+
+/**
+ * Fetch currently-active passenger information messages for an origin and
+ * destination station pair.
+ *
+ * The Digitraffic API quirks the URL must work around:
+ * - Repeated `station=` params do NOT OR together — only the last value is
+ *   honoured (verified empirically: HKI+LH returns LH-only results). So we
+ *   issue one request per station and merge the results client-side.
+ * - Comma-separated `station` values are also rejected.
+ * - Exactly one `train_departure_date` per request; multiples are rejected or
+ *   silently fail. So we also fan out per unique date when requested.
+ *
+ * Final request count is `stationCodes.length * max(uniqueDates.length, 1)`.
+ * Results are merged and deduplicated by message id.
+ *
+ * Pass `generalOnly: true` to fetch only messages with `trainNumber === null`.
+ */
+export async function fetchActivePassengerMessages(opts: {
+	stationCodes: string[];
+	departureDates?: string[];
+	generalOnly?: boolean;
+}): Promise<PassengerInformationMessage[]> {
+	const stationCodes = Array.from(new Set(opts.stationCodes.filter(Boolean)));
+	if (stationCodes.length === 0) return [];
+
+	const uniqueDates = opts.generalOnly
+		? [undefined]
+		: Array.from(new Set((opts.departureDates ?? []).filter(Boolean)));
+	if (uniqueDates.length === 0) return [];
+
+	const tasks: Promise<PassengerInformationMessage[]>[] = [];
+	for (const station of stationCodes) {
+		for (const date of uniqueDates) {
+			const url = buildPassengerInfoUrl({
+				station,
+				generalOnly: opts.generalOnly,
+				departureDate: date,
+			});
+			tasks.push(
+				requestPassengerInfo(url).catch((error) => {
+					console.error(
+						`Failed to fetch passenger info for station=${station} date=${date ?? "-"}:`,
+						error,
+					);
+					return [] as PassengerInformationMessage[];
+				}),
+			);
+		}
+	}
+
+	const settled = await Promise.all(tasks);
+	const merged = new Map<string, PassengerInformationMessage>();
+	for (const batch of settled) {
+		for (const msg of batch) {
+			if (!merged.has(msg.id)) merged.set(msg.id, msg);
+		}
+	}
+	return Array.from(merged.values());
+}
+
+// Test-only helper to reset the cache between unit tests.
+export function __resetPassengerInfoCacheForTests(): void {
+	passengerInfoCache.clear();
 }
 
 /**

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -848,12 +848,17 @@ function processTrainData(
 					`Train ${train.trainNumber} does not stop at ${stationCode}`,
 				);
 			}
-			return firstStationIndex === -1
-				? null
-				: {
-						...train,
-						timeTableRows: train.timeTableRows.slice(firstStationIndex),
-					};
+			if (firstStationIndex === -1) return null;
+			// Capture the train's true first-origin scheduled time before slicing
+			// — passenger-information messages key on the train's origin date,
+			// which differs from the selected station for midnight-crossing or
+			// previously-originated services.
+			const sliced: Train = {
+				...train,
+				originDepartureTime: train.timeTableRows[0]?.scheduledTime,
+				timeTableRows: train.timeTableRows.slice(firstStationIndex),
+			};
+			return sliced;
 		})
 		.filter((train): train is Train => {
 			if (!train) return false;

--- a/src/utils/helsinkiTime.ts
+++ b/src/utils/helsinkiTime.ts
@@ -1,0 +1,95 @@
+/** @format */
+/**
+ * Europe/Helsinki time helpers for the passenger-information feature.
+ *
+ * `deliveryRules.startTime`/`endTime` from Digitraffic are Helsinki
+ * wall-clock strings (`H:mm` or `HH:mm`); broadcast windows happen
+ * physically at Finnish stations regardless of the viewer's locale.
+ */
+
+export type Weekday =
+	| "MONDAY"
+	| "TUESDAY"
+	| "WEDNESDAY"
+	| "THURSDAY"
+	| "FRIDAY"
+	| "SATURDAY"
+	| "SUNDAY";
+
+interface HelsinkiParts {
+	date: string; // YYYY-MM-DD
+	time: string; // HH:mm
+	weekday: Weekday;
+	hour: number;
+	minute: number;
+}
+
+const partsFormatter = new Intl.DateTimeFormat("en-CA", {
+	timeZone: "Europe/Helsinki",
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+	weekday: "long",
+});
+
+/**
+ * Decompose an instant into Helsinki-local calendar parts.
+ */
+export function helsinkiParts(d: Date): HelsinkiParts {
+	const map = new Map<string, string>();
+	for (const part of partsFormatter.formatToParts(d)) {
+		map.set(part.type, part.value);
+	}
+	const year = map.get("year") ?? "1970";
+	const month = map.get("month") ?? "01";
+	const day = map.get("day") ?? "01";
+	// `hour: "2-digit"` with `hour12: false` can yield "24" at midnight in some
+	// runtimes; normalise to "00" so minute arithmetic stays well-defined.
+	const hourRaw = map.get("hour") ?? "00";
+	const hour = hourRaw === "24" ? 0 : Number.parseInt(hourRaw, 10);
+	const minute = Number.parseInt(map.get("minute") ?? "0", 10);
+	const weekday = (map.get("weekday") ?? "MONDAY").toUpperCase() as Weekday;
+	return {
+		date: `${year}-${month}-${day}`,
+		time: `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`,
+		weekday,
+		hour,
+		minute,
+	};
+}
+
+/**
+ * Parse a Helsinki wall-clock `H:mm` or `HH:mm` string into minutes since midnight.
+ * Returns null if the input cannot be parsed.
+ */
+export function toMinutes(t: string | undefined): number | null {
+	if (!t) return null;
+	const match = /^(\d{1,2}):(\d{2})$/.exec(t.trim());
+	if (!match) return null;
+	const hours = Number.parseInt(match[1], 10);
+	const minutes = Number.parseInt(match[2], 10);
+	if (hours > 23 || minutes > 59) return null;
+	return hours * 60 + minutes;
+}
+
+const validityFormatter = new Intl.DateTimeFormat("fi-FI", {
+	timeZone: "Europe/Helsinki",
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit",
+	hour: "2-digit",
+	minute: "2-digit",
+});
+
+/**
+ * Format an ISO timestamp as Helsinki-local `d.M.YYYY HH:mm` style for the
+ * banner validity footer.
+ */
+export function formatValidityHelsinki(iso: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	return validityFormatter.format(d);
+}

--- a/src/utils/helsinkiTime.ts
+++ b/src/utils/helsinkiTime.ts
@@ -31,7 +31,11 @@ const partsFormatter = new Intl.DateTimeFormat("en-CA", {
 	day: "2-digit",
 	hour: "2-digit",
 	minute: "2-digit",
-	hour12: false,
+	// `hourCycle: "h23"` forces 00–23 output. `hour12: false` is ambiguous and
+	// can resolve to "h24" (01–24) in some runtimes, where midnight is "24"
+	// paired with the *previous* calendar day — which would silently break
+	// Helsinki-date-based keys around midnight.
+	hourCycle: "h23",
 	weekday: "long",
 });
 
@@ -46,10 +50,7 @@ export function helsinkiParts(d: Date): HelsinkiParts {
 	const year = map.get("year") ?? "1970";
 	const month = map.get("month") ?? "01";
 	const day = map.get("day") ?? "01";
-	// `hour: "2-digit"` with `hour12: false` can yield "24" at midnight in some
-	// runtimes; normalise to "00" so minute arithmetic stays well-defined.
-	const hourRaw = map.get("hour") ?? "00";
-	const hour = hourRaw === "24" ? 0 : Number.parseInt(hourRaw, 10);
+	const hour = Number.parseInt(map.get("hour") ?? "00", 10);
 	const minute = Number.parseInt(map.get("minute") ?? "0", 10);
 	const weekday = (map.get("weekday") ?? "MONDAY").toUpperCase() as Weekday;
 	return {

--- a/src/utils/passengerInfo.ts
+++ b/src/utils/passengerInfo.ts
@@ -140,12 +140,12 @@ function applyTimeOfDayToInstant(
 	if (mins == null) return baseMs;
 	// Take the Helsinki-local calendar date of the base instant and combine it
 	// with the override time-of-day. Build the resulting instant via UTC math
-	// using the Helsinki offset at that instant.
+	// using the Helsinki offset at the *target* wall-clock, not the base — so
+	// windows that straddle a DST transition resolve to the right instant.
 	const baseParts = helsinkiParts(new Date(baseMs));
 	const [year, month, day] = baseParts.date.split("-").map(Number);
 	const targetHour = Math.floor(mins / 60);
 	const targetMinute = mins % 60;
-	// Recover the Helsinki UTC offset (in ms) at the base instant.
 	const baseHelsinkiMs = Date.UTC(
 		year,
 		month - 1,
@@ -153,7 +153,6 @@ function applyTimeOfDayToInstant(
 		baseParts.hour,
 		baseParts.minute,
 	);
-	const offsetMs = baseHelsinkiMs - baseMs;
 	const targetHelsinkiMs = Date.UTC(
 		year,
 		month - 1,
@@ -161,7 +160,17 @@ function applyTimeOfDayToInstant(
 		targetHour,
 		targetMinute,
 	);
-	return targetHelsinkiMs - offsetMs;
+	// Estimate using the base instant's offset, then correct: if Helsinki time
+	// at the estimate doesn't match the target wall-clock, we crossed a DST
+	// boundary and need to shift by the difference (typically ±60 minutes).
+	let estimateMs = targetHelsinkiMs - (baseHelsinkiMs - baseMs);
+	const estParts = helsinkiParts(new Date(estimateMs));
+	const wantMin = targetHour * 60 + targetMinute;
+	const gotMin = estParts.hour * 60 + estParts.minute;
+	if (gotMin !== wantMin) {
+		estimateMs += (wantMin - gotMin) * 60_000;
+	}
+	return estimateMs;
 }
 
 /**

--- a/src/utils/passengerInfo.ts
+++ b/src/utils/passengerInfo.ts
@@ -1,0 +1,230 @@
+/** @format */
+
+import { helsinkiParts, toMinutes, type Weekday } from "./helsinkiTime";
+
+export interface VideoDeliveryRules {
+	startDateTime: string; // ISO UTC
+	endDateTime: string; // ISO UTC
+	startTime?: string; // Helsinki wall-clock "H:mm" or "HH:mm"
+	endTime?: string;
+	weekDays: Weekday[];
+	deliveryType: "CONTINUOS_VISUALIZATION" | "WHEN";
+}
+
+export interface VideoChannel {
+	text: {
+		fi: string | null;
+		sv: string | null;
+		en: string | null;
+	};
+	deliveryRules?: VideoDeliveryRules;
+}
+
+export interface PassengerInformationMessage {
+	id: string;
+	version?: number;
+	creationDateTime?: string;
+	startValidity: string;
+	endValidity: string;
+	trainNumber: number | null;
+	trainDepartureDate: string | null;
+	stations: string[];
+	video?: VideoChannel;
+	/* Audio channel intentionally omitted — feature is video-only. */
+}
+
+export interface ActiveMessage {
+	id: string;
+	text: string;
+	trainNumber: number | null;
+	trainDepartureDate: string | null;
+	startValidity: string;
+	endValidity: string;
+}
+
+/**
+ * Pick the displayable text for the active language from the video channel.
+ * Falls back lang → en → fi → sv. Returns null when the message has no
+ * displayable video text (audio is ignored intentionally).
+ */
+export function pickDisplay(
+	msg: PassengerInformationMessage,
+	lang: string,
+): { text: string; rules: VideoDeliveryRules | undefined } | null {
+	const video = msg.video;
+	if (!video) return null;
+	const text =
+		(video.text as Record<string, string | null>)[lang] ??
+		video.text.en ??
+		video.text.fi ??
+		video.text.sv ??
+		null;
+	if (!text) return null;
+	return { text, rules: video.deliveryRules };
+}
+
+function inWeekdays(
+	weekDays: Weekday[] | undefined,
+	weekday: Weekday,
+): boolean {
+	if (!weekDays || weekDays.length === 0) return true;
+	return weekDays.includes(weekday);
+}
+
+/**
+ * Determine whether a video deliveryRules window currently covers `now`.
+ *
+ * Two delivery types are supported:
+ *
+ * - `CONTINUOS_VISUALIZATION` is a single continuous window between
+ *   (startDateTime + startTime) and (endDateTime + endTime), gated by
+ *   weekDays. The startTime/endTime modify the start/end of the overall
+ *   window only — they do NOT create a daily on/off cycle.
+ * - `WHEN` is a daily time-of-day window within the outer date range,
+ *   honouring weekDays. Handles overnight wrap when startTime > endTime.
+ *
+ * No rules → true (rely on the server's outer validity).
+ */
+export function isWithinRules(
+	rules: VideoDeliveryRules | undefined,
+	now: Date,
+): boolean {
+	if (!rules) return true;
+
+	const nowMs = now.getTime();
+	const here = helsinkiParts(now);
+
+	if (rules.deliveryType === "CONTINUOS_VISUALIZATION") {
+		const startMs = applyTimeOfDayToInstant(
+			rules.startDateTime,
+			rules.startTime,
+		);
+		const endMs = applyTimeOfDayToInstant(rules.endDateTime, rules.endTime);
+		if (Number.isNaN(startMs) || Number.isNaN(endMs)) return false;
+		if (nowMs < startMs || nowMs >= endMs) return false;
+		return inWeekdays(rules.weekDays, here.weekday);
+	}
+
+	// WHEN
+	const outerStartMs = new Date(rules.startDateTime).getTime();
+	const outerEndMs = new Date(rules.endDateTime).getTime();
+	if (Number.isNaN(outerStartMs) || Number.isNaN(outerEndMs)) return false;
+	if (nowMs < outerStartMs || nowMs >= outerEndMs) return false;
+	if (!inWeekdays(rules.weekDays, here.weekday)) return false;
+
+	const startMin = toMinutes(rules.startTime);
+	const endMin = toMinutes(rules.endTime);
+	if (startMin == null || endMin == null) {
+		// Without a daily window, fall back to outer-window membership.
+		return true;
+	}
+	const currentMin = here.hour * 60 + here.minute;
+	if (startMin === endMin) return false;
+	if (startMin < endMin) {
+		return currentMin >= startMin && currentMin < endMin;
+	}
+	// Overnight wrap (e.g. 22:00–06:00)
+	return currentMin >= startMin || currentMin < endMin;
+}
+
+/**
+ * Compose an instant from a UTC datetime plus an optional Helsinki wall-clock
+ * time-of-day override. Returns the original instant when no override applies.
+ */
+function applyTimeOfDayToInstant(
+	isoUtc: string,
+	timeOfDay: string | undefined,
+): number {
+	const baseMs = new Date(isoUtc).getTime();
+	const mins = toMinutes(timeOfDay);
+	if (mins == null) return baseMs;
+	// Take the Helsinki-local calendar date of the base instant and combine it
+	// with the override time-of-day. Build the resulting instant via UTC math
+	// using the Helsinki offset at that instant.
+	const baseParts = helsinkiParts(new Date(baseMs));
+	const [year, month, day] = baseParts.date.split("-").map(Number);
+	const targetHour = Math.floor(mins / 60);
+	const targetMinute = mins % 60;
+	// Recover the Helsinki UTC offset (in ms) at the base instant.
+	const baseHelsinkiMs = Date.UTC(
+		year,
+		month - 1,
+		day,
+		baseParts.hour,
+		baseParts.minute,
+	);
+	const offsetMs = baseHelsinkiMs - baseMs;
+	const targetHelsinkiMs = Date.UTC(
+		year,
+		month - 1,
+		day,
+		targetHour,
+		targetMinute,
+	);
+	return targetHelsinkiMs - offsetMs;
+}
+
+/**
+ * Filter raw messages down to the active set and route them into the
+ * general-banner pool and a per-train key map.
+ */
+export function partitionActiveMessages(
+	messages: PassengerInformationMessage[],
+	now: Date,
+	lang: string,
+	displayedTrainKeys: Set<string>,
+): {
+	general: ActiveMessage[];
+	perTrain: Map<string, ActiveMessage[]>;
+} {
+	const general: ActiveMessage[] = [];
+	const perTrain = new Map<string, ActiveMessage[]>();
+	const seen = new Set<string>();
+
+	for (const msg of messages) {
+		if (seen.has(msg.id)) continue;
+		seen.add(msg.id);
+
+		const display = pickDisplay(msg, lang);
+		if (!display) continue;
+		if (!isWithinRules(display.rules, now)) continue;
+
+		const active: ActiveMessage = {
+			id: msg.id,
+			text: display.text,
+			trainNumber: msg.trainNumber,
+			trainDepartureDate: msg.trainDepartureDate,
+			startValidity: msg.startValidity,
+			endValidity: msg.endValidity,
+		};
+
+		if (msg.trainNumber == null) {
+			general.push(active);
+			continue;
+		}
+
+		if (!msg.trainDepartureDate) continue;
+		const key = `${msg.trainNumber}_${msg.trainDepartureDate}`;
+		if (!displayedTrainKeys.has(key)) continue;
+		const existing = perTrain.get(key);
+		if (existing) {
+			existing.push(active);
+		} else {
+			perTrain.set(key, [active]);
+		}
+	}
+
+	return { general, perTrain };
+}
+
+/**
+ * Build the per-train key used to match a displayed train against incoming
+ * messages. `trainDepartureDate` is the train's first-origin departure date
+ * (which may be the previous calendar day for midnight-crossing trains).
+ */
+export function trainMessageKey(
+	trainNumber: number | string,
+	trainDepartureDate: string,
+): string {
+	return `${trainNumber}_${trainDepartureDate}`;
+}

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -100,6 +100,16 @@ export const translations = {
 		trackChangedNotification: "Raide muuttunut",
 		connectionIssue: "Yhteysongelma, näytetään viimeisin tieto",
 		close: "Sulje",
+		// Passenger information messages
+		passengerInfoBannerTitle: "Tiedotteet",
+		passengerInfoExpand: "Näytä tiedotteet",
+		passengerInfoCollapse: "Piilota tiedotteet",
+		passengerInfoTrainButton: "Näytä junan tiedote",
+		passengerInfoPrev: "Edellinen tiedote",
+		passengerInfoNext: "Seuraava tiedote",
+		passengerInfoIndicator: "Tiedote",
+		passengerInfoValidity: "Voimassa",
+		passengerInfoValidityRange: "{start} – {end}",
 	},
 	en: {
 		title: "Local Trains Live | Real-time schedules for local trains",
@@ -198,6 +208,16 @@ export const translations = {
 		trackChangedNotification: "Track changed",
 		connectionIssue: "Connection issue, showing last known data",
 		close: "Close",
+		// Passenger information messages
+		passengerInfoBannerTitle: "Announcements",
+		passengerInfoExpand: "Show announcements",
+		passengerInfoCollapse: "Hide announcements",
+		passengerInfoTrainButton: "Show train announcement",
+		passengerInfoPrev: "Previous announcement",
+		passengerInfoNext: "Next announcement",
+		passengerInfoIndicator: "Announcement",
+		passengerInfoValidity: "Valid",
+		passengerInfoValidityRange: "{start} – {end}",
 	},
 	sv: {
 		title: "Lokaltåg Live | Tidtabeller för lokaltåg i realtid",
@@ -296,6 +316,16 @@ export const translations = {
 		trackChangedNotification: "Spår ändrat",
 		connectionIssue: "Anslutningsproblem, visar senast kända data",
 		close: "Stäng",
+		// Passenger information messages
+		passengerInfoBannerTitle: "Meddelanden",
+		passengerInfoExpand: "Visa meddelanden",
+		passengerInfoCollapse: "Dölj meddelanden",
+		passengerInfoTrainButton: "Visa tågmeddelande",
+		passengerInfoPrev: "Föregående meddelande",
+		passengerInfoNext: "Nästa meddelande",
+		passengerInfoIndicator: "Meddelande",
+		passengerInfoValidity: "Giltigt",
+		passengerInfoValidityRange: "{start} – {end}",
 	},
 };
 

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -111,6 +111,11 @@ export const translations = {
 		passengerInfoValidity: "Voimassa",
 		passengerInfoValidityRange: "{start} – {end}",
 		passengerInfoDismiss: "Sulje tiedotteet",
+		passengerInfoConfirmPrompt:
+			"Haluatko nähdä tiedotteet myöhemmin uudelleen?",
+		passengerInfoConfirmDaily: "Piilota tältä päivältä",
+		passengerInfoConfirmNever: "Älä näytä enää",
+		passengerInfoConfirmCancel: "Peruuta",
 		newFeaturesPassengerInfo: "Aseman tiedotteet näkyvillä",
 	},
 	en: {
@@ -221,6 +226,11 @@ export const translations = {
 		passengerInfoValidity: "Valid",
 		passengerInfoValidityRange: "{start} – {end}",
 		passengerInfoDismiss: "Hide announcements",
+		passengerInfoConfirmPrompt:
+			"Would you like to see announcements again later?",
+		passengerInfoConfirmDaily: "Hide for today",
+		passengerInfoConfirmNever: "Don't show again",
+		passengerInfoConfirmCancel: "Cancel",
 		newFeaturesPassengerInfo: "Live station announcements",
 	},
 	sv: {
@@ -331,6 +341,10 @@ export const translations = {
 		passengerInfoValidity: "Giltigt",
 		passengerInfoValidityRange: "{start} – {end}",
 		passengerInfoDismiss: "Stäng meddelanden",
+		passengerInfoConfirmPrompt: "Vill du se meddelandena igen senare?",
+		passengerInfoConfirmDaily: "Dölj idag",
+		passengerInfoConfirmNever: "Visa inte igen",
+		passengerInfoConfirmCancel: "Avbryt",
 		newFeaturesPassengerInfo: "Stationsmeddelanden i realtid",
 	},
 };

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -110,6 +110,8 @@ export const translations = {
 		passengerInfoIndicator: "Tiedote",
 		passengerInfoValidity: "Voimassa",
 		passengerInfoValidityRange: "{start} – {end}",
+		passengerInfoDismiss: "Sulje tiedotteet",
+		newFeaturesPassengerInfo: "Aseman tiedotteet näkyvillä",
 	},
 	en: {
 		title: "Local Trains Live | Real-time schedules for local trains",
@@ -218,6 +220,8 @@ export const translations = {
 		passengerInfoIndicator: "Announcement",
 		passengerInfoValidity: "Valid",
 		passengerInfoValidityRange: "{start} – {end}",
+		passengerInfoDismiss: "Hide announcements",
+		newFeaturesPassengerInfo: "Live station announcements",
 	},
 	sv: {
 		title: "Lokaltåg Live | Tidtabeller för lokaltåg i realtid",
@@ -326,6 +330,8 @@ export const translations = {
 		passengerInfoIndicator: "Meddelande",
 		passengerInfoValidity: "Giltigt",
 		passengerInfoValidityRange: "{start} – {end}",
+		passengerInfoDismiss: "Stäng meddelanden",
+		newFeaturesPassengerInfo: "Stationsmeddelanden i realtid",
 	},
 };
 


### PR DESCRIPTION
## Summary
- Surfaces Digitraffic's /v1/passenger-information/active messages in two places: a collapsible general-announcement banner above the train list, and an inline icon-button + reveal panel on each TrainCard that has a matching active message
- Filters messages to the currently active set using the video channel's deliveryRules (CONTINUOS_VISUALIZATION + WHEN) with Europe/Helsinki wall-clock semantics, re-evaluated every second from TrainList's existing currentTime tick
- Carousel auto-advances every 20s with a 400ms crossfade between messages, pauses on hover/focus, with paging dots and prev/next controls

## API quirks worked around
- Repeated \`station=\` query params do NOT OR together — Digitraffic only honours the last value (verified: HKI then LH returns 0 messages, LH then HKI returns 3)
- Comma-separated \`station\` values are rejected
- Only one \`train_departure_date\` per request

The fetcher in \`src/utils/api.ts\` now fans out one request per (station, date) pair (cached 60s per URL) and merges the results, deduplicating by message id. This is what fixes the original \"HKI→LH shows no announcements, LH→HKI shows them\" asymmetry.

## Test plan
- [ ] \`pnpm run dev\`; in the Network tab confirm 2 \`only_general=true\` requests (one per station) per refresh tick, and 2×N \`train_departure_date\` requests for N unique displayed dates
- [ ] HKI ↔ LH (either direction) shows the same general announcements
- [ ] MLO as origin or destination → banner shows the Malminkartano closure notice
- [ ] HKI as origin → banner shows the Kehärata trackwork notice; both visible together carousel between them
- [ ] Click the banner to expand; carousel crossfades smoothly every 20s and pauses on hover
- [ ] Per-train: load a fixture via \`src/__tests__/fixtures/passengerInfo.ts\`, verify the amber info icon appears top-right of the card and the panel reveals inline below the row
- [ ] \`pnpm run lint\`, \`pnpm run typecheck\`, and \`pnpm run test\` all pass (140 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passenger information system: expandable banner, carousel with auto-advance, per-train message panels, and optional validity ranges with multi-language support
* **Tests**
  * Comprehensive unit tests and fixtures covering message selection, timing rules, partitioning, and fetch behavior
* **Documentation**
  * Added localized UI strings and release-note flag for passenger info
* **Chores**
  * Project version bumped to 1.15.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikosalonen/lahijunat.live/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->